### PR TITLE
IRQ-based VirtIOBlk access.

### DIFF
--- a/src/blk.rs
+++ b/src/blk.rs
@@ -77,7 +77,7 @@ impl VirtIOBlk<'_> {
     ///
     /// * `block_id` - The identifier of the block to read.
     /// * `buf` - The buffer in the memory which the block is read into.
-    /// * `resp` - A mutable reference to a variable provided by the caller 
+    /// * `resp` - A mutable reference to a variable provided by the caller
     ///   which contains the status of the requests. The caller can safely
     ///   read the variable only after the request is ready.
     ///
@@ -89,17 +89,19 @@ impl VirtIOBlk<'_> {
     ///
     /// After the request is ready, `resp` will be updated and the caller can get the
     /// status of the request(e.g. succeed or failed) through it. However, the caller
-    /// **must not** spin on `resp` to wait for it to change. A safe way is to read it 
+    /// **must not** spin on `resp` to wait for it to change. A safe way is to read it
     /// after the same token as this method returns is fetched through [VirtIOBlk::pop_used()],
     /// which means that the request has been ready.
     pub fn read_block_nb(&mut self, block_id: usize, buf: &mut [u8], resp: &mut u8) -> Result<u16> {
-        assert_eq!(buf.len(), BLK_SIZE); 
+        assert_eq!(buf.len(), BLK_SIZE);
         let req = BlkReq {
             type_: ReqType::In,
             reserved: 0,
             sector: block_id as u64,
         };
-        let token = self.queue.add(&[req.as_buf()], &[buf, core::slice::from_mut(resp)])?;
+        let token = self
+            .queue
+            .add(&[req.as_buf()], &[buf, core::slice::from_mut(resp)])?;
         self.header.notify(0);
         Ok(token)
     }
@@ -131,7 +133,7 @@ impl VirtIOBlk<'_> {
     ///
     /// * `block_id` - The identifier of the block to write.
     /// * `buf` - The buffer in the memory containing the data to write to the block.
-    /// * `resp` - A mutable reference to a variable provided by the caller 
+    /// * `resp` - A mutable reference to a variable provided by the caller
     ///   which contains the status of the requests. The caller can safely
     ///   read the variable only after the request is ready.
     ///
@@ -139,28 +141,30 @@ impl VirtIOBlk<'_> {
     ///
     /// See also [VirtIOBlk::read_block_nb()].
     pub fn write_block_nb(&mut self, block_id: usize, buf: &[u8], resp: &mut u8) -> Result<u16> {
-        assert_eq!(buf.len(), BLK_SIZE); 
+        assert_eq!(buf.len(), BLK_SIZE);
         let req = BlkReq {
             type_: ReqType::Out,
             reserved: 0,
             sector: block_id as u64,
         };
-        let token = self.queue.add(&[req.as_buf(), buf], &[core::slice::from_mut(resp)])?;
+        let token = self
+            .queue
+            .add(&[req.as_buf(), buf], &[core::slice::from_mut(resp)])?;
         self.header.notify(0);
         Ok(token)
     }
 
     /// During an interrupt, it fetches a token of a completed request from the used
-    /// ring and return it. If all completed requests have already been fetched, return 
+    /// ring and return it. If all completed requests have already been fetched, return
     /// Err(Error::NotReady).
     pub fn pop_used(&mut self) -> Result<u16> {
-        self.queue.pop_used().map(|p| p.0)  
+        self.queue.pop_used().map(|p| p.0)
     }
 
-    /// Return size of its VirtQueue. 
+    /// Return size of its VirtQueue.
     /// It can be used to tell the caller how many channels he should monitor on.
     pub fn virt_queue_size(&self) -> u16 {
-        self.queue.size() 
+        self.queue.size()
     }
 }
 

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -92,7 +92,19 @@ impl VirtIOBlk<'_> {
     /// **must not** spin on `resp` to wait for it to change. A safe way is to read it
     /// after the same token as this method returns is fetched through [VirtIOBlk::pop_used()],
     /// which means that the request has been ready.
-    pub fn read_block_nb(&mut self, block_id: usize, buf: &mut [u8], resp: &mut u8) -> Result<u16> {
+    ///
+    /// # Safety
+    ///
+    /// `buf` is still borrowed by the underlying virtio block device even if this
+    /// method returns. Thus, it is the caller's responsibility to guarantee that
+    /// `buf` is not accessed before the request is completed in order to avoid
+    /// data races.
+    pub unsafe fn read_block_nb(
+        &mut self,
+        block_id: usize,
+        buf: &mut [u8],
+        resp: &mut u8,
+    ) -> Result<u16> {
         assert_eq!(buf.len(), BLK_SIZE);
         let req = BlkReq {
             type_: ReqType::In,
@@ -140,7 +152,16 @@ impl VirtIOBlk<'_> {
     /// # Usage
     ///
     /// See also [VirtIOBlk::read_block_nb()].
-    pub fn write_block_nb(&mut self, block_id: usize, buf: &[u8], resp: &mut u8) -> Result<u16> {
+    ///
+    /// # Safety
+    ///
+    /// See also [VirtIOBlk::read_block_nb()].
+    pub unsafe fn write_block_nb(
+        &mut self,
+        block_id: usize,
+        buf: &[u8],
+        resp: &mut u8,
+    ) -> Result<u16> {
         assert_eq!(buf.len(), BLK_SIZE);
         let req = BlkReq {
             type_: ReqType::Out,

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -71,6 +71,39 @@ impl VirtIOBlk<'_> {
         }
     }
 
+    /// Read a block in a non-blocking way which means that it returns immediately.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_id` - The identifier of the block to read.
+    /// * `buf` - The buffer in the memory which the block is read into.
+    /// * `resp` - A mutable reference to a variable provided by the caller 
+    ///   which contains the status of the requests. The caller can safely
+    ///   read the variable only after the request is ready.
+    ///
+    /// # Usage
+    ///
+    /// It will submit request to the virtio block device and return a token identifying
+    /// the position of the first Descriptor in the chain. If there are not enough
+    /// Descriptors to allocate, then it returns [Error::BufferTooSmall].
+    ///
+    /// After the request is ready, `resp` will be updated and the caller can get the
+    /// status of the request(e.g. succeed or failed) through it. However, the caller
+    /// **must not** spin on `resp` to wait for it to change. A safe way is to read it 
+    /// after the same token as this method returns is fetched through [VirtIOBlk::pop_used()],
+    /// which means that the request has been ready.
+    pub fn read_block_nb(&mut self, block_id: usize, buf: &mut [u8], resp: &mut u8) -> Result<u16> {
+        assert_eq!(buf.len(), BLK_SIZE); 
+        let req = BlkReq {
+            type_: ReqType::In,
+            reserved: 0,
+            sector: block_id as u64,
+        };
+        let token = self.queue.add(&[req.as_buf()], &[buf, core::slice::from_mut(resp)])?;
+        self.header.notify(0);
+        Ok(token)
+    }
+
     /// Write a block.
     pub fn write_block(&mut self, block_id: usize, buf: &[u8]) -> Result {
         assert_eq!(buf.len(), BLK_SIZE);
@@ -90,6 +123,44 @@ impl VirtIOBlk<'_> {
             RespStatus::Ok => Ok(()),
             _ => Err(Error::IoError),
         }
+    }
+
+    //// Write a block in a non-blocking way which means that it returns immediately.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_id` - The identifier of the block to write.
+    /// * `buf` - The buffer in the memory containing the data to write to the block.
+    /// * `resp` - A mutable reference to a variable provided by the caller 
+    ///   which contains the status of the requests. The caller can safely
+    ///   read the variable only after the request is ready.
+    ///
+    /// # Usage
+    ///
+    /// See also [VirtIOBlk::read_block_nb()].
+    pub fn write_block_nb(&mut self, block_id: usize, buf: &[u8], resp: &mut u8) -> Result<u16> {
+        assert_eq!(buf.len(), BLK_SIZE); 
+        let req = BlkReq {
+            type_: ReqType::Out,
+            reserved: 0,
+            sector: block_id as u64,
+        };
+        let token = self.queue.add(&[req.as_buf(), buf], &[core::slice::from_mut(resp)])?;
+        self.header.notify(0);
+        Ok(token)
+    }
+
+    /// During an interrupt, it fetches a token of a completed request from the used
+    /// ring and return it. If all completed requests have already been fetched, return 
+    /// Err(Error::NotReady).
+    pub fn pop_used(&mut self) -> Result<u16> {
+        self.queue.pop_used().map(|p| p.0)  
+    }
+
+    /// Return size of its VirtQueue. 
+    /// It can be used to tell the caller how many channels he should monitor on.
+    pub fn virt_queue_size(&self) -> u16 {
+        self.queue.size() 
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod input;
 mod net;
 mod queue;
 
-pub use self::blk::VirtIOBlk;
+pub use self::blk::{BlkResp, RespStatus, VirtIOBlk};
 pub use self::console::VirtIOConsole;
 pub use self::gpu::VirtIOGpu;
 pub use self::header::*;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -173,7 +173,7 @@ impl VirtQueue<'_> {
 
     /// Return size of the queue.
     pub fn size(&self) -> u16 {
-        self.queue_size 
+        self.queue_size
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -170,6 +170,11 @@ impl VirtQueue<'_> {
 
         Ok((index, len))
     }
+
+    /// Return size of the queue.
+    pub fn size(&self) -> u16 {
+        self.queue_size 
+    }
 }
 
 /// The inner layout of a VirtQueue.


### PR DESCRIPTION
Now VirtIOBlk device can be accessed in a non-blocking way based on IRQ, and we keep the interface compatible with the ecosystem which relies on this library since we did not change or remove any existing interface.

We only added 5 methods:
* `VirtIOBlk::read_block_nb`
* `VirtIOBlk::write_block_nb`
* `VirtIOBlk::pop_used`
* `VirtIOBlk::virt_queue_size`
* `VirtQueue::size`(only called by `VirtIOBlk::virt_queue_size`)

Their usage has been included in the code documentation.

## How to use them
1. Initialization: Call `virt_queue_size` to get the number of channels the caller should monitor on. Every descriptor in the descriptor table is called a channel. For example:
```rust
// condvars: BTreeMap<u16, Condvar>
let mut condvars = BTreeMap::new();
let channels = virtio_blk.exclusive_access().virt_queue_size();
for i in 0..channels {
    let condvar = Condvar::new(); 
    condvars.insert(i, condvar);
}
```
2. Read/write a block: Call `read_block_nb` or `write_block_nb` to get the token of the request immediately, then block on the channel whose identifier is the same as the token. After the thread is woken up, we can read `resp` which stores the status of the request to check if the request was successfully completed.
```rust
let mut blk = self.virtio_blk.exclusive_access();
let mut resp = 0xffu8;
let token = blk.write_block_nb(block_id, buf, &mut resp).unwrap();
drop(blk);
self.condvars.get(&token).unwrap().wait();
assert_eq!(resp, 0x0, "Error when reading VirtIOBlk");
```
3. Handling interrupts: When an interrupt is received, the user calls `pop_used` to fetch all of the completed requests' token from the used ring, and then wake up the threads that block on the corresponding channels. For example:
```rust
fn handle_irq(&self) {
    let mut blk = self.virtio_blk.exclusive_access(); 
    while let Ok(token) = blk.pop_used() {
        self.condvars.get(&token).unwrap().signal();
    }
}
```
## Publicity of `BlkResp`
Now the user should provide a variable `resp` of type `u8` to store the status of the request. Should we make [`BlkResp`](https://github.com/rcore-os/virtio-drivers/blob/master/src/blk.rs#L122) public so that we can use it instead of `u8` to enhance the type safety? I have no idea yet.