### PR TITLE
Use macros individually.

### DIFF
--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -2,16 +2,13 @@
 #![no_main]
 #![deny(warnings)]
 
-#[macro_use]
 extern crate alloc;
-#[macro_use]
-extern crate log;
-// #[macro_use]
 extern crate opensbi_rt;
 
 use device_tree::util::SliceRead;
 use device_tree::{DeviceTree, Node};
-use log::LevelFilter;
+use log::{info, LevelFilter, warn};
+use alloc::vec;
 use virtio_drivers::*;
 
 mod virtio_impl;

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -1,5 +1,6 @@
 use core::sync::atomic::*;
 use lazy_static::lazy_static;
+use log::trace;
 
 extern "C" {
     fn end();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,6 @@
 #![allow(clippy::identity_op)]
 #![allow(dead_code)]
 
-// #[macro_use]
-extern crate log;
-
 extern crate alloc;
 
 mod blk;


### PR DESCRIPTION
This is neater and more hygenic, and available since Rust 2018.