### PR TITLE
Use a safer approach to the HAL interface

### DIFF
--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -10,6 +10,7 @@ use device_tree::util::SliceRead;
 use device_tree::{DeviceTree, Node};
 use log::{info, warn, LevelFilter};
 use virtio_drivers::*;
+use virtio_impl::HalImpl;
 
 mod virtio_impl;
 
@@ -72,7 +73,7 @@ fn virtio_probe(node: &Node) {
 }
 
 fn virtio_blk(header: &'static mut VirtIOHeader) {
-    let mut blk = VirtIOBlk::new(header).expect("failed to create blk driver");
+    let mut blk = VirtIOBlk::<HalImpl>::new(header).expect("failed to create blk driver");
     let mut input = vec![0xffu8; 512];
     let mut output = vec![0; 512];
     for i in 0..32 {
@@ -87,7 +88,7 @@ fn virtio_blk(header: &'static mut VirtIOHeader) {
 }
 
 fn virtio_gpu(header: &'static mut VirtIOHeader) {
-    let mut gpu = VirtIOGpu::new(header).expect("failed to create gpu driver");
+    let mut gpu = VirtIOGpu::<HalImpl>::new(header).expect("failed to create gpu driver");
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
     for y in 0..768 {
         for x in 0..1024 {
@@ -103,7 +104,7 @@ fn virtio_gpu(header: &'static mut VirtIOHeader) {
 
 fn virtio_input(header: &'static mut VirtIOHeader) {
     //let mut event_buf = [0u64; 32];
-    let mut _input = VirtIOInput::new(header).expect("failed to create input driver");
+    let mut _input = VirtIOInput::<HalImpl>::new(header).expect("failed to create input driver");
     // loop {
     //     input.ack_interrupt().expect("failed to ack");
     //     info!("mouse: {:?}", input.mouse_xy());
@@ -112,7 +113,7 @@ fn virtio_input(header: &'static mut VirtIOHeader) {
 }
 
 fn virtio_net(header: &'static mut VirtIOHeader) {
-    let mut net = VirtIONet::new(header).expect("failed to create net driver");
+    let mut net = VirtIONet::<HalImpl>::new(header).expect("failed to create net driver");
     let mut buf = [0u8; 0x100];
     let len = net.recv(&mut buf).expect("failed to recv");
     info!("recv: {:?}", &buf[..len]);

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -1,6 +1,7 @@
 use core::sync::atomic::*;
 use lazy_static::lazy_static;
 use log::trace;
+use virtio_drivers::{PhysAddr, VirtAddr};
 
 extern "C" {
     fn end();
@@ -32,6 +33,3 @@ extern "C" fn virtio_phys_to_virt(paddr: PhysAddr) -> VirtAddr {
 extern "C" fn virtio_virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
     vaddr
 }
-
-type VirtAddr = usize;
-type PhysAddr = usize;

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::*;
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{PhysAddr, VirtAddr};
+use virtio_drivers::{Hal, PhysAddr, VirtAddr};
 
 extern "C" {
     fn end();
@@ -11,25 +11,25 @@ lazy_static! {
     static ref DMA_PADDR: AtomicUsize = AtomicUsize::new(end as usize);
 }
 
-#[no_mangle]
-extern "C" fn virtio_dma_alloc(pages: usize) -> PhysAddr {
-    let paddr = DMA_PADDR.fetch_add(0x1000 * pages, Ordering::SeqCst);
-    trace!("alloc DMA: paddr={:#x}, pages={}", paddr, pages);
-    paddr
-}
+pub struct HalImpl;
 
-#[no_mangle]
-extern "C" fn virtio_dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
-    trace!("dealloc DMA: paddr={:#x}, pages={}", paddr, pages);
-    0
-}
+impl Hal for HalImpl {
+    fn dma_alloc(pages: usize) -> PhysAddr {
+        let paddr = DMA_PADDR.fetch_add(0x1000 * pages, Ordering::SeqCst);
+        trace!("alloc DMA: paddr={:#x}, pages={}", paddr, pages);
+        paddr
+    }
 
-#[no_mangle]
-extern "C" fn virtio_phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-    paddr
-}
+    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
+        trace!("dealloc DMA: paddr={:#x}, pages={}", paddr, pages);
+        0
+    }
 
-#[no_mangle]
-extern "C" fn virtio_virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-    vaddr
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        paddr
+    }
+
+    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+        vaddr
+    }
 }

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -10,13 +10,13 @@ use volatile::Volatile;
 ///
 /// Read and write requests (and other exotic requests) are placed in the queue,
 /// and serviced (probably out of order) by the device except where noted.
-pub struct VirtIOBlk<'a> {
+pub struct VirtIOBlk<'a, H: Hal> {
     header: &'static mut VirtIOHeader,
-    queue: VirtQueue<'a>,
+    queue: VirtQueue<'a, H>,
     capacity: usize,
 }
 
-impl VirtIOBlk<'_> {
+impl<H: Hal> VirtIOBlk<'_, H> {
     /// Create a new VirtIO-Blk driver.
     pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
         header.begin_init(|features| {

--- a/src/console.rs
+++ b/src/console.rs
@@ -10,17 +10,17 @@ const QUEUE_TRANSMITQ_PORT_0: usize = 1;
 
 /// Virtio console. Only one single port is allowed since ``alloc'' is disabled.
 /// Emergency and cols/rows unimplemented.
-pub struct VirtIOConsole<'a> {
+pub struct VirtIOConsole<'a, H: Hal> {
     header: &'static mut VirtIOHeader,
-    receiveq: VirtQueue<'a>,
-    transmitq: VirtQueue<'a>,
-    queue_buf_dma: DMA,
+    receiveq: VirtQueue<'a, H>,
+    transmitq: VirtQueue<'a, H>,
+    queue_buf_dma: DMA<H>,
     queue_buf_rx: &'a mut [u8],
     cursor: usize,
     pending_len: usize,
 }
 
-impl<'a> VirtIOConsole<'a> {
+impl<H: Hal> VirtIOConsole<'_, H> {
     /// Create a new VirtIO-Console driver.
     pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
         header.begin_init(|features| {

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -1,7 +1,10 @@
 use super::*;
 
-type VirtAddr = usize;
-type PhysAddr = usize;
+/// A virtual memory address in the address space of the program.
+pub type VirtAddr = usize;
+
+/// A physical address as used for virtio.
+pub type PhysAddr = usize;
 
 /// A region of contiguous physical memory used for DMA.
 pub struct DMA {

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::marker::PhantomData;
 
 /// A virtual memory address in the address space of the program.
 pub type VirtAddr = usize;
@@ -7,20 +8,22 @@ pub type VirtAddr = usize;
 pub type PhysAddr = usize;
 
 /// A region of contiguous physical memory used for DMA.
-pub struct DMA {
+pub struct DMA<H: Hal> {
     paddr: u32,
     pages: u32,
+    _phantom: PhantomData<H>,
 }
 
-impl DMA {
+impl<H: Hal> DMA<H> {
     pub fn new(pages: usize) -> Result<Self> {
-        let paddr = unsafe { virtio_dma_alloc(pages) };
+        let paddr = H::dma_alloc(pages);
         if paddr == 0 {
             return Err(Error::DmaError);
         }
         Ok(DMA {
             paddr: paddr as u32,
             pages: pages as u32,
+            _phantom: PhantomData::default(),
         })
     }
 
@@ -29,7 +32,7 @@ impl DMA {
     }
 
     pub fn vaddr(&self) -> usize {
-        phys_to_virt(self.paddr as usize)
+        H::phys_to_virt(self.paddr as usize)
     }
 
     /// Returns the physical page frame number.
@@ -43,24 +46,23 @@ impl DMA {
     }
 }
 
-impl Drop for DMA {
+impl<H: Hal> Drop for DMA<H> {
     fn drop(&mut self) {
-        let err = unsafe { virtio_dma_dealloc(self.paddr as usize, self.pages as usize) };
+        let err = H::dma_dealloc(self.paddr as usize, self.pages as usize);
         assert_eq!(err, 0, "failed to deallocate DMA");
     }
 }
 
-pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-    unsafe { virtio_phys_to_virt(paddr) }
-}
-
-pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-    unsafe { virtio_virt_to_phys(vaddr) }
-}
-
-extern "C" {
-    fn virtio_dma_alloc(pages: usize) -> PhysAddr;
-    fn virtio_dma_dealloc(paddr: PhysAddr, pages: usize) -> i32;
-    fn virtio_phys_to_virt(paddr: PhysAddr) -> VirtAddr;
-    fn virtio_virt_to_phys(vaddr: VirtAddr) -> PhysAddr;
+/// The interface which a particular hardware implementation must implement.
+pub trait Hal {
+    /// Allocates the given number of contiguous physical pages of DMA memory for virtio use.
+    fn dma_alloc(pages: usize) -> PhysAddr;
+    /// Deallocates the given contiguous physical DMA memory pages.
+    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32;
+    /// Converts a physical address used for virtio to a virtual address which the program can
+    /// access.
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr;
+    /// Converts a virtual address which the program can access to the corresponding physical
+    /// address to use for virtio.
+    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr;
 }

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -9,8 +9,8 @@ pub type PhysAddr = usize;
 
 /// A region of contiguous physical memory used for DMA.
 pub struct DMA<H: Hal> {
-    paddr: u32,
-    pages: u32,
+    paddr: usize,
+    pages: usize,
     _phantom: PhantomData<H>,
 }
 
@@ -21,23 +21,23 @@ impl<H: Hal> DMA<H> {
             return Err(Error::DmaError);
         }
         Ok(DMA {
-            paddr: paddr as u32,
-            pages: pages as u32,
+            paddr,
+            pages,
             _phantom: PhantomData::default(),
         })
     }
 
     pub fn paddr(&self) -> usize {
-        self.paddr as usize
+        self.paddr
     }
 
     pub fn vaddr(&self) -> usize {
-        H::phys_to_virt(self.paddr as usize)
+        H::phys_to_virt(self.paddr)
     }
 
     /// Returns the physical page frame number.
     pub fn pfn(&self) -> u32 {
-        self.paddr >> 12
+        (self.paddr >> 12) as u32
     }
 
     /// Convert to a buffer

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,14 +9,14 @@ use volatile::{ReadOnly, WriteOnly};
 /// An instance of the virtio device represents one such input device.
 /// Device behavior mirrors that of the evdev layer in Linux,
 /// making pass-through implementations on top of evdev easy.
-pub struct VirtIOInput<'a> {
+pub struct VirtIOInput<'a, H: Hal> {
     header: &'static mut VirtIOHeader,
-    event_queue: VirtQueue<'a>,
-    status_queue: VirtQueue<'a>,
+    event_queue: VirtQueue<'a, H>,
+    status_queue: VirtQueue<'a, H>,
     event_buf: Box<[InputEvent; 32]>,
 }
 
-impl<'a> VirtIOInput<'a> {
+impl<'a, H: Hal> VirtIOInput<'a, H> {
     /// Create a new VirtIO-Input driver.
     pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod queue;
 pub use self::blk::{BlkResp, RespStatus, VirtIOBlk};
 pub use self::console::VirtIOConsole;
 pub use self::gpu::VirtIOGpu;
-pub use self::hal::{PhysAddr, VirtAddr};
+pub use self::hal::{Hal, PhysAddr, VirtAddr};
 pub use self::header::*;
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod queue;
 pub use self::blk::{BlkResp, RespStatus, VirtIOBlk};
 pub use self::console::VirtIOConsole;
 pub use self::gpu::VirtIOGpu;
+pub use self::hal::{PhysAddr, VirtAddr};
 pub use self::header::*;
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;

--- a/src/net.rs
+++ b/src/net.rs
@@ -13,14 +13,14 @@ use volatile::{ReadOnly, Volatile};
 /// Empty buffers are placed in one virtqueue for receiving packets, and
 /// outgoing packets are enqueued into another for transmission in that order.
 /// A third command queue is used to control advanced filtering features.
-pub struct VirtIONet<'a> {
+pub struct VirtIONet<'a, H: Hal> {
     header: &'static mut VirtIOHeader,
     mac: EthernetAddress,
-    recv_queue: VirtQueue<'a>,
-    send_queue: VirtQueue<'a>,
+    recv_queue: VirtQueue<'a, H>,
+    send_queue: VirtQueue<'a, H>,
 }
 
-impl VirtIONet<'_> {
+impl<H: Hal> VirtIONet<'_, H> {
     /// Create a new VirtIO-Net driver.
     pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
         header.begin_init(|features| {


### PR DESCRIPTION
Rather than rely on `extern "C"` functions, this makes the HAL a trait that must be implemented and provided as a type parameter. This lets it be properly type checked and removes a bunch of `unsafe` blocks.