### PR TITLE
Add tests for VirtQueue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,17 +25,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --all-features
-    - name: Docs
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+      - name: Docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+pub mod fake;
+
 use super::*;
 use core::marker::PhantomData;
 
@@ -8,6 +11,7 @@ pub type VirtAddr = usize;
 pub type PhysAddr = usize;
 
 /// A region of contiguous physical memory used for DMA.
+#[derive(Debug)]
 pub struct DMA<H: Hal> {
     paddr: usize,
     pages: usize,

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -1,0 +1,41 @@
+//! Fake HAL implementation for tests.
+
+use crate::{Hal, PhysAddr, VirtAddr, PAGE_SIZE};
+use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
+use core::alloc::Layout;
+
+#[derive(Debug)]
+pub struct FakeHal;
+
+/// Fake HAL implementation for use in unit tests.
+impl Hal for FakeHal {
+    fn dma_alloc(pages: usize) -> PhysAddr {
+        assert_ne!(pages, 0);
+        let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
+        // Safe because the size and alignment of the layout are non-zero.
+        let ptr = unsafe { alloc_zeroed(layout) };
+        if ptr.is_null() {
+            handle_alloc_error(layout);
+        }
+        ptr as PhysAddr
+    }
+
+    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
+        assert_ne!(pages, 0);
+        let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
+        // Safe because the layout is the same as was used when the memory was allocated by
+        // `dma_alloc` above.
+        unsafe {
+            dealloc(paddr as *mut u8, layout);
+        }
+        0
+    }
+
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        paddr
+    }
+
+    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+        vaddr
+    }
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -11,7 +11,6 @@ use volatile::Volatile;
 /// The mechanism for bulk data transport on virtio devices.
 ///
 /// Each device can have zero or more virtqueues.
-#[repr(C)]
 #[derive(Debug)]
 pub struct VirtQueue<'a, H: Hal> {
     /// DMA guard

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -296,4 +296,23 @@ mod tests {
             Error::AlreadyUsed
         );
     }
+
+    #[test]
+    fn add_empty() {
+        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        assert_eq!(queue.add(&[], &[]).unwrap_err(), Error::InvalidParam);
+    }
+
+    #[test]
+    fn add_too_big() {
+        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        assert_eq!(
+            queue
+                .add(&[&[], &[], &[]], &[&mut [], &mut []])
+                .unwrap_err(),
+            Error::BufferTooSmall
+        );
+    }
 }


### PR DESCRIPTION
I'd like to add tests for the device implementations too, but that's going to require some refactoring to allow the transport to be faked somehow.