### PR TITLE
Factor out trait for transport, and add support for modern MMIO transport

### DIFF
--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -36,7 +36,7 @@ header:
 clean:
 	cargo clean
 
-qemu: kernel $(img)
+qemu-legacy: kernel $(img)
 	qemu-system-$(arch) \
 		-machine virt \
 		-serial mon:stdio \
@@ -49,7 +49,21 @@ qemu: kernel $(img)
 		# -netdev type=tap,id=net0,script=no,downscript=no \
 		# -device virtio-net-device,netdev=net0
 
+qemu: kernel $(img)
+	qemu-system-$(arch) \
+		-machine virt \
+		-serial mon:stdio \
+		-bios default \
+		-kernel $(kernel) \
+		-global virtio-mmio.force-legacy=false \
+		-drive file=$(img),if=none,format=raw,id=x0 \
+		-device virtio-blk-device,drive=x0 \
+		-device virtio-gpu-device \
+		-device virtio-mouse-device \
+		# -netdev type=tap,id=net0,script=no,downscript=no \
+		# -device virtio-net-device,netdev=net0
+
 $(img):
 	dd if=/dev/zero of=$@ bs=512 count=32
 
-run: build qemu
+run: build qemu-legacy qemu

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -8,7 +8,7 @@ extern crate opensbi_rt;
 use alloc::vec;
 use device_tree::util::SliceRead;
 use device_tree::{DeviceTree, Node};
-use log::{info, warn, LevelFilter};
+use log::{error, info, warn, LevelFilter};
 use virtio_drivers::*;
 use virtio_impl::HalImpl;
 
@@ -55,26 +55,45 @@ fn virtio_probe(node: &Node) {
         let size = reg.as_slice().read_be_u64(8).unwrap();
         let vaddr = paddr;
         info!("walk dt addr={:#x}, size={:#x}", paddr, size);
-        let header = unsafe { &mut *(vaddr as *mut LegacyMmioTransport) };
-        info!(
-            "Detected virtio device with vendor id {:#X}, device type {:?}",
-            header.vendor_id(),
-            header.device_type(),
-        );
         info!("Device tree node {:?}", node);
-        match header.device_type() {
-            DeviceType::Block => virtio_blk(header),
-            DeviceType::GPU => virtio_gpu(header),
-            DeviceType::Input => virtio_input(header),
-            DeviceType::Network => virtio_net(header),
-            t => warn!("Unrecognized virtio device: {:?}", t),
+        let header = vaddr as *mut VirtIOHeader;
+        match unsafe { (*header).version() } {
+            Some(1) => {
+                let transport = unsafe { &mut *(header as *mut LegacyMmioTransport) };
+                info!(
+                    "Detected virtio legacy MMIO device with vendor id {:#X}, device type {:?}",
+                    transport.vendor_id(),
+                    transport.device_type(),
+                );
+                virtio_device(transport);
+            }
+            Some(2) => {
+                let transport = unsafe { &mut *(header as *mut MmioTransport) };
+                info!(
+                    "Detected virtio MMIO device with vendor id {:#X}, device type {:?}",
+                    transport.vendor_id(),
+                    transport.device_type(),
+                );
+                virtio_device(transport);
+            }
+            Some(version) => warn!("Unsupported virtio MMIO version {}", version),
+            None => error!("Invalid magic value for virtio device"),
         }
     }
 }
 
-fn virtio_blk(header: &'static mut LegacyMmioTransport) {
-    let mut blk = VirtIOBlk::<HalImpl, LegacyMmioTransport>::new(header)
-        .expect("failed to create blk driver");
+fn virtio_device(transport: &'static mut impl Transport) {
+    match transport.device_type() {
+        DeviceType::Block => virtio_blk(transport),
+        DeviceType::GPU => virtio_gpu(transport),
+        DeviceType::Input => virtio_input(transport),
+        DeviceType::Network => virtio_net(transport),
+        t => warn!("Unrecognized virtio device: {:?}", t),
+    }
+}
+
+fn virtio_blk<T: Transport>(transport: &'static mut T) {
+    let mut blk = VirtIOBlk::<HalImpl, T>::new(transport).expect("failed to create blk driver");
     let mut input = vec![0xffu8; 512];
     let mut output = vec![0; 512];
     for i in 0..32 {
@@ -88,9 +107,8 @@ fn virtio_blk(header: &'static mut LegacyMmioTransport) {
     info!("virtio-blk test finished");
 }
 
-fn virtio_gpu(header: &'static mut LegacyMmioTransport) {
-    let mut gpu = VirtIOGpu::<HalImpl, LegacyMmioTransport>::new(header)
-        .expect("failed to create gpu driver");
+fn virtio_gpu<T: Transport>(transport: &'static mut T) {
+    let mut gpu = VirtIOGpu::<HalImpl, T>::new(transport).expect("failed to create gpu driver");
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
     for y in 0..768 {
         for x in 0..1024 {
@@ -104,10 +122,10 @@ fn virtio_gpu(header: &'static mut LegacyMmioTransport) {
     info!("virtio-gpu test finished");
 }
 
-fn virtio_input(header: &'static mut LegacyMmioTransport) {
+fn virtio_input<T: Transport>(transport: &'static mut T) {
     //let mut event_buf = [0u64; 32];
-    let mut _input = VirtIOInput::<HalImpl, LegacyMmioTransport>::new(header)
-        .expect("failed to create input driver");
+    let mut _input =
+        VirtIOInput::<HalImpl, T>::new(transport).expect("failed to create input driver");
     // loop {
     //     input.ack_interrupt().expect("failed to ack");
     //     info!("mouse: {:?}", input.mouse_xy());
@@ -115,9 +133,8 @@ fn virtio_input(header: &'static mut LegacyMmioTransport) {
     // TODO: handle external interrupt
 }
 
-fn virtio_net(header: &'static mut LegacyMmioTransport) {
-    let mut net = VirtIONet::<HalImpl, LegacyMmioTransport>::new(header)
-        .expect("failed to create net driver");
+fn virtio_net<T: Transport>(transport: &'static mut T) {
+    let mut net = VirtIONet::<HalImpl, T>::new(transport).expect("failed to create net driver");
     let mut buf = [0u8; 0x100];
     let len = net.recv(&mut buf).expect("failed to recv");
     info!("recv: {:?}", &buf[..len]);

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -55,7 +55,7 @@ fn virtio_probe(node: &Node) {
         let size = reg.as_slice().read_be_u64(8).unwrap();
         let vaddr = paddr;
         info!("walk dt addr={:#x}, size={:#x}", paddr, size);
-        let header = unsafe { &mut *(vaddr as *mut VirtIOHeader) };
+        let header = unsafe { &mut *(vaddr as *mut LegacyMmioTransport) };
         info!(
             "Detected virtio device with vendor id {:#X}, device type {:?}",
             header.vendor_id(),
@@ -72,9 +72,9 @@ fn virtio_probe(node: &Node) {
     }
 }
 
-fn virtio_blk(header: &'static mut VirtIOHeader) {
-    let mut blk =
-        VirtIOBlk::<HalImpl, VirtIOHeader>::new(header).expect("failed to create blk driver");
+fn virtio_blk(header: &'static mut LegacyMmioTransport) {
+    let mut blk = VirtIOBlk::<HalImpl, LegacyMmioTransport>::new(header)
+        .expect("failed to create blk driver");
     let mut input = vec![0xffu8; 512];
     let mut output = vec![0; 512];
     for i in 0..32 {
@@ -88,9 +88,9 @@ fn virtio_blk(header: &'static mut VirtIOHeader) {
     info!("virtio-blk test finished");
 }
 
-fn virtio_gpu(header: &'static mut VirtIOHeader) {
-    let mut gpu =
-        VirtIOGpu::<HalImpl, VirtIOHeader>::new(header).expect("failed to create gpu driver");
+fn virtio_gpu(header: &'static mut LegacyMmioTransport) {
+    let mut gpu = VirtIOGpu::<HalImpl, LegacyMmioTransport>::new(header)
+        .expect("failed to create gpu driver");
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
     for y in 0..768 {
         for x in 0..1024 {
@@ -104,10 +104,10 @@ fn virtio_gpu(header: &'static mut VirtIOHeader) {
     info!("virtio-gpu test finished");
 }
 
-fn virtio_input(header: &'static mut VirtIOHeader) {
+fn virtio_input(header: &'static mut LegacyMmioTransport) {
     //let mut event_buf = [0u64; 32];
-    let mut _input =
-        VirtIOInput::<HalImpl, VirtIOHeader>::new(header).expect("failed to create input driver");
+    let mut _input = VirtIOInput::<HalImpl, LegacyMmioTransport>::new(header)
+        .expect("failed to create input driver");
     // loop {
     //     input.ack_interrupt().expect("failed to ack");
     //     info!("mouse: {:?}", input.mouse_xy());
@@ -115,9 +115,9 @@ fn virtio_input(header: &'static mut VirtIOHeader) {
     // TODO: handle external interrupt
 }
 
-fn virtio_net(header: &'static mut VirtIOHeader) {
-    let mut net =
-        VirtIONet::<HalImpl, VirtIOHeader>::new(header).expect("failed to create net driver");
+fn virtio_net(header: &'static mut LegacyMmioTransport) {
+    let mut net = VirtIONet::<HalImpl, LegacyMmioTransport>::new(header)
+        .expect("failed to create net driver");
     let mut buf = [0u8; 0x100];
     let len = net.recv(&mut buf).expect("failed to recv");
     info!("recv: {:?}", &buf[..len]);

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -73,7 +73,8 @@ fn virtio_probe(node: &Node) {
 }
 
 fn virtio_blk(header: &'static mut VirtIOHeader) {
-    let mut blk = VirtIOBlk::<HalImpl>::new(header).expect("failed to create blk driver");
+    let mut blk =
+        VirtIOBlk::<HalImpl, VirtIOHeader>::new(header).expect("failed to create blk driver");
     let mut input = vec![0xffu8; 512];
     let mut output = vec![0; 512];
     for i in 0..32 {
@@ -88,7 +89,8 @@ fn virtio_blk(header: &'static mut VirtIOHeader) {
 }
 
 fn virtio_gpu(header: &'static mut VirtIOHeader) {
-    let mut gpu = VirtIOGpu::<HalImpl>::new(header).expect("failed to create gpu driver");
+    let mut gpu =
+        VirtIOGpu::<HalImpl, VirtIOHeader>::new(header).expect("failed to create gpu driver");
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
     for y in 0..768 {
         for x in 0..1024 {
@@ -104,7 +106,8 @@ fn virtio_gpu(header: &'static mut VirtIOHeader) {
 
 fn virtio_input(header: &'static mut VirtIOHeader) {
     //let mut event_buf = [0u64; 32];
-    let mut _input = VirtIOInput::<HalImpl>::new(header).expect("failed to create input driver");
+    let mut _input =
+        VirtIOInput::<HalImpl, VirtIOHeader>::new(header).expect("failed to create input driver");
     // loop {
     //     input.ack_interrupt().expect("failed to ack");
     //     info!("mouse: {:?}", input.mouse_xy());
@@ -113,7 +116,8 @@ fn virtio_input(header: &'static mut VirtIOHeader) {
 }
 
 fn virtio_net(header: &'static mut VirtIOHeader) {
-    let mut net = VirtIONet::<HalImpl>::new(header).expect("failed to create net driver");
+    let mut net =
+        VirtIONet::<HalImpl, VirtIOHeader>::new(header).expect("failed to create net driver");
     let mut buf = [0u8; 0x100];
     let len = net.recv(&mut buf).expect("failed to recv");
     info!("recv: {:?}", &buf[..len]);

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -83,9 +83,8 @@ fn virtio_device(transport: impl Transport) {
     }
 }
 
-fn virtio_blk<T: Transport>(mut transport: T) {
-    let mut blk =
-        VirtIOBlk::<HalImpl, T>::new(&mut transport).expect("failed to create blk driver");
+fn virtio_blk<T: Transport>(transport: T) {
+    let mut blk = VirtIOBlk::<HalImpl, T>::new(transport).expect("failed to create blk driver");
     let mut input = vec![0xffu8; 512];
     let mut output = vec![0; 512];
     for i in 0..32 {
@@ -99,9 +98,8 @@ fn virtio_blk<T: Transport>(mut transport: T) {
     info!("virtio-blk test finished");
 }
 
-fn virtio_gpu<T: Transport>(mut transport: T) {
-    let mut gpu =
-        VirtIOGpu::<HalImpl, T>::new(&mut transport).expect("failed to create gpu driver");
+fn virtio_gpu<T: Transport>(transport: T) {
+    let mut gpu = VirtIOGpu::<HalImpl, T>::new(transport).expect("failed to create gpu driver");
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
     for y in 0..768 {
         for x in 0..1024 {
@@ -115,10 +113,10 @@ fn virtio_gpu<T: Transport>(mut transport: T) {
     info!("virtio-gpu test finished");
 }
 
-fn virtio_input<T: Transport>(mut transport: T) {
+fn virtio_input<T: Transport>(transport: T) {
     //let mut event_buf = [0u64; 32];
     let mut _input =
-        VirtIOInput::<HalImpl, T>::new(&mut transport).expect("failed to create input driver");
+        VirtIOInput::<HalImpl, T>::new(transport).expect("failed to create input driver");
     // loop {
     //     input.ack_interrupt().expect("failed to ack");
     //     info!("mouse: {:?}", input.mouse_xy());
@@ -126,9 +124,8 @@ fn virtio_input<T: Transport>(mut transport: T) {
     // TODO: handle external interrupt
 }
 
-fn virtio_net<T: Transport>(mut transport: T) {
-    let mut net =
-        VirtIONet::<HalImpl, T>::new(&mut transport).expect("failed to create net driver");
+fn virtio_net<T: Transport>(transport: T) {
+    let mut net = VirtIONet::<HalImpl, T>::new(transport).expect("failed to create net driver");
     let mut buf = [0u8; 0x100];
     let len = net.recv(&mut buf).expect("failed to recv");
     info!("recv: {:?}", &buf[..len]);

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -16,7 +16,7 @@ pub struct VirtIOBlk<'a, H: Hal, T: Transport> {
     capacity: usize,
 }
 
-impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
+impl<H: Hal, T: Transport> VirtIOBlk<'_, H, T> {
     /// Create a new VirtIO-Blk driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::header::VirtIOHeader;
 use crate::queue::VirtQueue;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use bitflags::*;
 use core::hint::spin_loop;
 use log::*;

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -11,14 +11,14 @@ use volatile::Volatile;
 /// Read and write requests (and other exotic requests) are placed in the queue,
 /// and serviced (probably out of order) by the device except where noted.
 pub struct VirtIOBlk<'a, H: Hal, T: Transport> {
-    transport: &'a mut T,
+    transport: T,
     queue: VirtQueue<'a, H>,
     capacity: usize,
 }
 
 impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
     /// Create a new VirtIO-Blk driver.
-    pub fn new(transport: &'a mut T) -> Result<Self> {
+    pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {
             let features = BlkFeature::from_bits_truncate(features);
             info!("device features: {:?}", features);
@@ -36,7 +36,7 @@ impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
             config.capacity.read() / 2
         );
 
-        let queue = VirtQueue::new(transport, 0, 16)?;
+        let queue = VirtQueue::new(&mut transport, 0, 16)?;
         transport.finish_init();
 
         Ok(VirtIOBlk {

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -28,7 +28,8 @@ impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
         });
 
         // read configuration space
-        let config = unsafe { transport.config_space().cast::<BlkConfig>().as_ref() };
+        let config_space = transport.config_space().cast::<BlkConfig>();
+        let config = unsafe { config_space.as_ref() };
         info!("config: {:?}", config);
         info!(
             "found a block device of size {}KB",

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -28,7 +28,7 @@ impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
         });
 
         // read configuration space
-        let config = unsafe { &mut *(transport.config_space() as *mut BlkConfig) };
+        let config = unsafe { transport.config_space().cast::<BlkConfig>().as_ref() };
         info!("config: {:?}", config);
         info!(
             "found a block device of size {}KB",

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::queue::VirtQueue;
-use crate::transport::{mmio::VirtIOHeader, Transport};
+use crate::transport::Transport;
 use bitflags::*;
 use core::hint::spin_loop;
 use log::*;
@@ -10,16 +10,16 @@ use volatile::Volatile;
 ///
 /// Read and write requests (and other exotic requests) are placed in the queue,
 /// and serviced (probably out of order) by the device except where noted.
-pub struct VirtIOBlk<'a, H: Hal> {
-    header: &'static mut VirtIOHeader,
+pub struct VirtIOBlk<'a, H: Hal, T: Transport> {
+    transport: &'a mut T,
     queue: VirtQueue<'a, H>,
     capacity: usize,
 }
 
-impl<H: Hal> VirtIOBlk<'_, H> {
+impl<'a, H: Hal, T: Transport> VirtIOBlk<'a, H, T> {
     /// Create a new VirtIO-Blk driver.
-    pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
-        header.begin_init(|features| {
+    pub fn new(transport: &'a mut T) -> Result<Self> {
+        transport.begin_init(|features| {
             let features = BlkFeature::from_bits_truncate(features);
             info!("device features: {:?}", features);
             // negotiate these flags only
@@ -28,18 +28,18 @@ impl<H: Hal> VirtIOBlk<'_, H> {
         });
 
         // read configuration space
-        let config = unsafe { &mut *(header.config_space() as *mut BlkConfig) };
+        let config = unsafe { &mut *(transport.config_space() as *mut BlkConfig) };
         info!("config: {:?}", config);
         info!(
             "found a block device of size {}KB",
             config.capacity.read() / 2
         );
 
-        let queue = VirtQueue::new(header, 0, 16)?;
-        header.finish_init();
+        let queue = VirtQueue::new(transport, 0, 16)?;
+        transport.finish_init();
 
         Ok(VirtIOBlk {
-            header,
+            transport,
             queue,
             capacity: config.capacity.read() as usize,
         })
@@ -47,7 +47,7 @@ impl<H: Hal> VirtIOBlk<'_, H> {
 
     /// Acknowledge interrupt.
     pub fn ack_interrupt(&mut self) -> bool {
-        self.header.ack_interrupt()
+        self.transport.ack_interrupt()
     }
 
     /// Read a block.
@@ -60,7 +60,7 @@ impl<H: Hal> VirtIOBlk<'_, H> {
         };
         let mut resp = BlkResp::default();
         self.queue.add(&[req.as_buf()], &[buf, resp.as_buf_mut()])?;
-        self.header.notify(0);
+        self.transport.notify(0);
         while !self.queue.can_pop() {
             spin_loop();
         }
@@ -112,7 +112,7 @@ impl<H: Hal> VirtIOBlk<'_, H> {
             sector: block_id as u64,
         };
         let token = self.queue.add(&[req.as_buf()], &[buf, resp.as_buf_mut()])?;
-        self.header.notify(0);
+        self.transport.notify(0);
         Ok(token)
     }
 
@@ -126,7 +126,7 @@ impl<H: Hal> VirtIOBlk<'_, H> {
         };
         let mut resp = BlkResp::default();
         self.queue.add(&[req.as_buf(), buf], &[resp.as_buf_mut()])?;
-        self.header.notify(0);
+        self.transport.notify(0);
         while !self.queue.can_pop() {
             spin_loop();
         }
@@ -167,7 +167,7 @@ impl<H: Hal> VirtIOBlk<'_, H> {
             sector: block_id as u64,
         };
         let token = self.queue.add(&[req.as_buf(), buf], &[resp.as_buf_mut()])?;
-        self.header.notify(0);
+        self.transport.notify(0);
         Ok(token)
     }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -49,10 +49,12 @@ impl<H: Hal> VirtIOConsole<'_, H> {
         console.poll_retrieve()?;
         Ok(console)
     }
+
     fn poll_retrieve(&mut self) -> Result<()> {
         self.receiveq.add(&[], &[self.queue_buf_rx])?;
         Ok(())
     }
+
     /// Acknowledge interrupt.
     pub fn ack_interrupt(&mut self) -> Result<bool> {
         let ack = self.header.ack_interrupt();
@@ -84,6 +86,7 @@ impl<H: Hal> VirtIOConsole<'_, H> {
         }
         Ok(Some(ch))
     }
+
     /// Put a char onto the device.
     pub fn send(&mut self, chr: u8) -> Result<()> {
         let buf: [u8; 1] = [chr];

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::queue::VirtQueue;
-use crate::transport::{mmio::VirtIOHeader, Transport};
+use crate::transport::Transport;
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
@@ -8,11 +8,12 @@ use volatile::{ReadOnly, WriteOnly};
 
 const QUEUE_RECEIVEQ_PORT_0: usize = 0;
 const QUEUE_TRANSMITQ_PORT_0: usize = 1;
+const QUEUE_SIZE: u16 = 2;
 
 /// Virtio console. Only one single port is allowed since ``alloc'' is disabled.
 /// Emergency and cols/rows unimplemented.
-pub struct VirtIOConsole<'a, H: Hal> {
-    header: &'static mut VirtIOHeader,
+pub struct VirtIOConsole<'a, H: Hal, T: Transport> {
+    transport: &'a mut T,
     receiveq: VirtQueue<'a, H>,
     transmitq: VirtQueue<'a, H>,
     queue_buf_dma: DMA<H>,
@@ -21,24 +22,24 @@ pub struct VirtIOConsole<'a, H: Hal> {
     pending_len: usize,
 }
 
-impl<H: Hal> VirtIOConsole<'_, H> {
+impl<'a, H: Hal, T: Transport> VirtIOConsole<'a, H, T> {
     /// Create a new VirtIO-Console driver.
-    pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
-        header.begin_init(|features| {
+    pub fn new(transport: &'a mut T) -> Result<Self> {
+        transport.begin_init(|features| {
             let features = Features::from_bits_truncate(features);
             info!("Device features {:?}", features);
             let supported_features = Features::empty();
             (features & supported_features).bits()
         });
-        let config = unsafe { &mut *(header.config_space() as *mut Config) };
+        let config = unsafe { &mut *(transport.config_space() as *mut Config) };
         info!("Config: {:?}", config);
-        let receiveq = VirtQueue::new(header, QUEUE_RECEIVEQ_PORT_0, 2)?;
-        let transmitq = VirtQueue::new(header, QUEUE_TRANSMITQ_PORT_0, 2)?;
+        let receiveq = VirtQueue::new(transport, QUEUE_RECEIVEQ_PORT_0, QUEUE_SIZE)?;
+        let transmitq = VirtQueue::new(transport, QUEUE_TRANSMITQ_PORT_0, QUEUE_SIZE)?;
         let queue_buf_dma = DMA::new(1)?;
         let queue_buf_rx = unsafe { &mut queue_buf_dma.as_buf()[0..] };
-        header.finish_init();
+        transport.finish_init();
         let mut console = VirtIOConsole {
-            header,
+            transport,
             receiveq,
             transmitq,
             queue_buf_dma,
@@ -57,7 +58,7 @@ impl<H: Hal> VirtIOConsole<'_, H> {
 
     /// Acknowledge interrupt.
     pub fn ack_interrupt(&mut self) -> Result<bool> {
-        let ack = self.header.ack_interrupt();
+        let ack = self.transport.ack_interrupt();
         if !ack {
             return Ok(false);
         }
@@ -91,7 +92,7 @@ impl<H: Hal> VirtIOConsole<'_, H> {
     pub fn send(&mut self, chr: u8) -> Result<()> {
         let buf: [u8; 1] = [chr];
         self.transmitq.add(&[&buf], &[])?;
-        self.header.notify(QUEUE_TRANSMITQ_PORT_0 as u32);
+        self.transport.notify(QUEUE_TRANSMITQ_PORT_0 as u32);
         while !self.transmitq.can_pop() {
             spin_loop();
         }

--- a/src/console.rs
+++ b/src/console.rs
@@ -31,7 +31,8 @@ impl<'a, H: Hal, T: Transport> VirtIOConsole<'a, H, T> {
             let supported_features = Features::empty();
             (features & supported_features).bits()
         });
-        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
+        let config_space = transport.config_space().cast::<Config>();
+        let config = unsafe { config_space.as_ref() };
         info!("Config: {:?}", config);
         let receiveq = VirtQueue::new(transport, QUEUE_RECEIVEQ_PORT_0, QUEUE_SIZE)?;
         let transmitq = VirtQueue::new(transport, QUEUE_TRANSMITQ_PORT_0, QUEUE_SIZE)?;

--- a/src/console.rs
+++ b/src/console.rs
@@ -31,7 +31,7 @@ impl<'a, H: Hal, T: Transport> VirtIOConsole<'a, H, T> {
             let supported_features = Features::empty();
             (features & supported_features).bits()
         });
-        let config = unsafe { &mut *(transport.config_space() as *mut Config) };
+        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
         info!("Config: {:?}", config);
         let receiveq = VirtQueue::new(transport, QUEUE_RECEIVEQ_PORT_0, QUEUE_SIZE)?;
         let transmitq = VirtQueue::new(transport, QUEUE_TRANSMITQ_PORT_0, QUEUE_SIZE)?;

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::queue::VirtQueue;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;

--- a/src/console.rs
+++ b/src/console.rs
@@ -22,7 +22,7 @@ pub struct VirtIOConsole<'a, H: Hal, T: Transport> {
     pending_len: usize,
 }
 
-impl<'a, H: Hal, T: Transport> VirtIOConsole<'a, H, T> {
+impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
     /// Create a new VirtIO-Console driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -43,7 +43,7 @@ impl<'a, H: Hal, T: Transport> VirtIOGpu<'a, H, T> {
         });
 
         // read configuration space
-        let config = unsafe { &mut *(transport.config_space() as *mut Config) };
+        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
         info!("Config: {:?}", config);
 
         let control_queue = VirtQueue::new(transport, QUEUE_TRANSMIT, 2)?;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -32,7 +32,7 @@ pub struct VirtIOGpu<'a, H: Hal, T: Transport> {
     queue_buf_recv: &'a mut [u8],
 }
 
-impl<'a, H: Hal, T: Transport> VirtIOGpu<'a, H, T> {
+impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
     /// Create a new VirtIO-Gpu driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::queue::VirtQueue;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -43,7 +43,8 @@ impl<'a, H: Hal, T: Transport> VirtIOGpu<'a, H, T> {
         });
 
         // read configuration space
-        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
+        let config_space = transport.config_space().cast::<Config>();
+        let config = unsafe { config_space.as_ref() };
         info!("Config: {:?}", config);
 
         let control_queue = VirtQueue::new(transport, QUEUE_TRANSMIT, 2)?;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::queue::VirtQueue;
-use crate::transport::{mmio::VirtIOHeader, Transport};
+use crate::transport::Transport;
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
@@ -13,8 +13,8 @@ use volatile::{ReadOnly, Volatile, WriteOnly};
 /// a gpu with 3D support on the host machine.
 /// In 2D mode the virtio-gpu device provides support for ARGB Hardware cursors
 /// and multiple scanouts (aka heads).
-pub struct VirtIOGpu<'a, H: Hal> {
-    header: &'static mut VirtIOHeader,
+pub struct VirtIOGpu<'a, H: Hal, T: Transport> {
+    transport: &'a mut T,
     rect: Rect,
     /// DMA area of frame buffer.
     frame_buffer_dma: Option<DMA<H>>,
@@ -32,10 +32,10 @@ pub struct VirtIOGpu<'a, H: Hal> {
     queue_buf_recv: &'a mut [u8],
 }
 
-impl<H: Hal> VirtIOGpu<'_, H> {
+impl<'a, H: Hal, T: Transport> VirtIOGpu<'a, H, T> {
     /// Create a new VirtIO-Gpu driver.
-    pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
-        header.begin_init(|features| {
+    pub fn new(transport: &'a mut T) -> Result<Self> {
+        transport.begin_init(|features| {
             let features = Features::from_bits_truncate(features);
             info!("Device features {:?}", features);
             let supported_features = Features::empty();
@@ -43,20 +43,20 @@ impl<H: Hal> VirtIOGpu<'_, H> {
         });
 
         // read configuration space
-        let config = unsafe { &mut *(header.config_space() as *mut Config) };
+        let config = unsafe { &mut *(transport.config_space() as *mut Config) };
         info!("Config: {:?}", config);
 
-        let control_queue = VirtQueue::new(header, QUEUE_TRANSMIT, 2)?;
-        let cursor_queue = VirtQueue::new(header, QUEUE_CURSOR, 2)?;
+        let control_queue = VirtQueue::new(transport, QUEUE_TRANSMIT, 2)?;
+        let cursor_queue = VirtQueue::new(transport, QUEUE_CURSOR, 2)?;
 
         let queue_buf_dma = DMA::new(2)?;
         let queue_buf_send = unsafe { &mut queue_buf_dma.as_buf()[..PAGE_SIZE] };
         let queue_buf_recv = unsafe { &mut queue_buf_dma.as_buf()[PAGE_SIZE..] };
 
-        header.finish_init();
+        transport.finish_init();
 
         Ok(VirtIOGpu {
-            header,
+            transport,
             frame_buffer_dma: None,
             cursor_buffer_dma: None,
             rect: Rect::default(),
@@ -70,7 +70,7 @@ impl<H: Hal> VirtIOGpu<'_, H> {
 
     /// Acknowledge interrupt.
     pub fn ack_interrupt(&mut self) -> bool {
-        self.header.ack_interrupt()
+        self.transport.ack_interrupt()
     }
 
     /// Get the resolution (width, height).
@@ -162,7 +162,7 @@ impl<H: Hal> VirtIOGpu<'_, H> {
         }
         self.control_queue
             .add(&[self.queue_buf_send], &[self.queue_buf_recv])?;
-        self.header.notify(QUEUE_TRANSMIT as u32);
+        self.transport.notify(QUEUE_TRANSMIT as u32);
         while !self.control_queue.can_pop() {
             spin_loop();
         }
@@ -176,7 +176,7 @@ impl<H: Hal> VirtIOGpu<'_, H> {
             (self.queue_buf_send.as_mut_ptr() as *mut Req).write(req);
         }
         self.cursor_queue.add(&[self.queue_buf_send], &[])?;
-        self.header.notify(QUEUE_CURSOR as u32);
+        self.transport.notify(QUEUE_CURSOR as u32);
         while !self.cursor_queue.can_pop() {
             spin_loop();
         }

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -39,11 +39,6 @@ impl<H: Hal> DMA<H> {
         H::phys_to_virt(self.paddr)
     }
 
-    /// Returns the physical page frame number.
-    pub fn pfn(&self) -> u32 {
-        (self.paddr >> 12) as u32
-    }
-
     /// Convert to a buffer
     pub unsafe fn as_buf(&self) -> &'static mut [u8] {
         core::slice::from_raw_parts_mut(self.vaddr() as _, PAGE_SIZE * self.pages as usize)

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,7 +17,7 @@ pub struct VirtIOInput<'a, H: Hal, T: Transport> {
     event_buf: Box<[InputEvent; 32]>,
 }
 
-impl<'a, H: Hal, T: Transport> VirtIOInput<'a, H, T> {
+impl<H: Hal, T: Transport> VirtIOInput<'_, H, T> {
     /// Create a new VirtIO-Input driver.
     pub fn new(mut transport: T) -> Result<Self> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::transport::{mmio::VirtIOHeader, Transport};
+use crate::transport::Transport;
 use alloc::boxed::Box;
 use bitflags::*;
 use log::*;
@@ -10,18 +10,18 @@ use volatile::{ReadOnly, WriteOnly};
 /// An instance of the virtio device represents one such input device.
 /// Device behavior mirrors that of the evdev layer in Linux,
 /// making pass-through implementations on top of evdev easy.
-pub struct VirtIOInput<'a, H: Hal> {
-    header: &'static mut VirtIOHeader,
+pub struct VirtIOInput<'a, H: Hal, T: Transport> {
+    transport: &'a mut T,
     event_queue: VirtQueue<'a, H>,
     status_queue: VirtQueue<'a, H>,
     event_buf: Box<[InputEvent; 32]>,
 }
 
-impl<'a, H: Hal> VirtIOInput<'a, H> {
+impl<'a, H: Hal, T: Transport> VirtIOInput<'a, H, T> {
     /// Create a new VirtIO-Input driver.
-    pub fn new(header: &'static mut VirtIOHeader) -> Result<Self> {
+    pub fn new(transport: &'a mut T) -> Result<Self> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);
-        header.begin_init(|features| {
+        transport.begin_init(|features| {
             let features = Feature::from_bits_truncate(features);
             info!("Device features: {:?}", features);
             // negotiate these flags only
@@ -29,17 +29,17 @@ impl<'a, H: Hal> VirtIOInput<'a, H> {
             (features & supported_features).bits()
         });
 
-        let mut event_queue = VirtQueue::new(header, QUEUE_EVENT, QUEUE_SIZE as u16)?;
-        let status_queue = VirtQueue::new(header, QUEUE_STATUS, QUEUE_SIZE as u16)?;
+        let mut event_queue = VirtQueue::new(transport, QUEUE_EVENT, QUEUE_SIZE as u16)?;
+        let status_queue = VirtQueue::new(transport, QUEUE_STATUS, QUEUE_SIZE as u16)?;
         for (i, event) in event_buf.as_mut().iter_mut().enumerate() {
             let token = event_queue.add(&[], &[event.as_buf_mut()])?;
             assert_eq!(token, i as u16);
         }
 
-        header.finish_init();
+        transport.finish_init();
 
         Ok(VirtIOInput {
-            header,
+            transport,
             event_queue,
             status_queue,
             event_buf,
@@ -48,7 +48,7 @@ impl<'a, H: Hal> VirtIOInput<'a, H> {
 
     /// Acknowledge interrupt and process events.
     pub fn ack_interrupt(&mut self) -> bool {
-        self.header.ack_interrupt()
+        self.transport.ack_interrupt()
     }
 
     /// Pop the pending event.
@@ -71,7 +71,7 @@ impl<'a, H: Hal> VirtIOInput<'a, H> {
         subsel: u8,
         out: &mut [u8],
     ) -> u8 {
-        let config = unsafe { &mut *(self.header.config_space() as *mut Config) };
+        let config = unsafe { &mut *(self.transport.config_space() as *mut Config) };
         config.select.write(select as u8);
         config.subsel.write(subsel);
         let size = config.size.read();

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,7 +71,8 @@ impl<'a, H: Hal, T: Transport> VirtIOInput<'a, H, T> {
         subsel: u8,
         out: &mut [u8],
     ) -> u8 {
-        let config = unsafe { self.transport.config_space().cast::<Config>().as_mut() };
+        let mut config_space = self.transport.config_space().cast::<Config>();
+        let config = unsafe { config_space.as_mut() };
         config.select.write(select as u8);
         config.subsel.write(subsel);
         let size = config.size.read();

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use alloc::boxed::Box;
 use bitflags::*;
 use log::*;

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,7 +71,7 @@ impl<'a, H: Hal, T: Transport> VirtIOInput<'a, H, T> {
         subsel: u8,
         out: &mut [u8],
     ) -> u8 {
-        let config = unsafe { &mut *(self.transport.config_space() as *mut Config) };
+        let config = unsafe { self.transport.config_space().cast::<Config>().as_mut() };
         config.select.write(select as u8);
         config.subsel.write(subsel);
         let size = config.size.read();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::hal::{Hal, PhysAddr, VirtAddr};
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
-pub use self::transport::mmio::{LegacyMmioTransport, MmioTransport, VirtIOHeader};
+pub use self::transport::mmio::{MmioError, MmioTransport, MmioVersion, VirtIOHeader};
 pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::hal::{Hal, PhysAddr, VirtAddr};
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
-pub use self::transport::mmio::VirtIOHeader;
+pub use self::transport::mmio::LegacyMmioTransport;
 pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,19 +11,20 @@ mod blk;
 mod console;
 mod gpu;
 mod hal;
-mod header;
 mod input;
 mod net;
 mod queue;
+mod transport;
 
 pub use self::blk::{BlkResp, RespStatus, VirtIOBlk};
 pub use self::console::VirtIOConsole;
 pub use self::gpu::VirtIOGpu;
 pub use self::hal::{Hal, PhysAddr, VirtAddr};
-pub use self::header::*;
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
+pub use self::transport::mmio::VirtIOHeader;
+pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::hal::{Hal, PhysAddr, VirtAddr};
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
-pub use self::transport::mmio::LegacyMmioTransport;
+pub use self::transport::mmio::{LegacyMmioTransport, MmioTransport};
 pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::hal::{Hal, PhysAddr, VirtAddr};
 pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
-pub use self::transport::mmio::{LegacyMmioTransport, MmioTransport};
+pub use self::transport::mmio::{LegacyMmioTransport, MmioTransport, VirtIOHeader};
 pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;

--- a/src/net.rs
+++ b/src/net.rs
@@ -31,7 +31,8 @@ impl<'a, H: Hal, T: Transport> VirtIONet<'a, H, T> {
             (features & supported_features).bits()
         });
         // read configuration space
-        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
+        let config_space = transport.config_space().cast::<Config>();
+        let config = unsafe { config_space.as_ref() };
         let mac = config.mac.read();
         debug!("Got MAC={:?}, status={:?}", mac, config.status.read());
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -21,7 +21,7 @@ pub struct VirtIONet<'a, H: Hal, T: Transport> {
     send_queue: VirtQueue<'a, H>,
 }
 
-impl<'a, H: Hal, T: Transport> VirtIONet<'a, H, T> {
+impl<H: Hal, T: Transport> VirtIONet<'_, H, T> {
     /// Create a new VirtIO-Net driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,6 +1,7 @@
 use core::mem::{size_of, MaybeUninit};
 
 use super::*;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use bitflags::*;
 use core::hint::spin_loop;
 use log::*;

--- a/src/net.rs
+++ b/src/net.rs
@@ -31,7 +31,7 @@ impl<'a, H: Hal, T: Transport> VirtIONet<'a, H, T> {
             (features & supported_features).bits()
         });
         // read configuration space
-        let config = unsafe { &mut *(transport.config_space() as *mut Config) };
+        let config = unsafe { transport.config_space().cast::<Config>().as_ref() };
         let mac = config.mac.read();
         debug!("Got MAC={:?}, status={:?}", mac, config.status.read());
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -15,7 +15,7 @@ use volatile::{ReadOnly, Volatile};
 /// outgoing packets are enqueued into another for transmission in that order.
 /// A third command queue is used to control advanced filtering features.
 pub struct VirtIONet<'a, H: Hal, T: Transport> {
-    transport: &'a mut T,
+    transport: T,
     mac: EthernetAddress,
     recv_queue: VirtQueue<'a, H>,
     send_queue: VirtQueue<'a, H>,
@@ -23,7 +23,7 @@ pub struct VirtIONet<'a, H: Hal, T: Transport> {
 
 impl<'a, H: Hal, T: Transport> VirtIONet<'a, H, T> {
     /// Create a new VirtIO-Net driver.
-    pub fn new(transport: &'a mut T) -> Result<Self> {
+    pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {
             let features = Features::from_bits_truncate(features);
             info!("Device features {:?}", features);
@@ -37,8 +37,8 @@ impl<'a, H: Hal, T: Transport> VirtIONet<'a, H, T> {
         debug!("Got MAC={:?}, status={:?}", mac, config.status.read());
 
         let queue_num = 2; // for simplicity
-        let recv_queue = VirtQueue::new(transport, QUEUE_RECEIVE, queue_num)?;
-        let send_queue = VirtQueue::new(transport, QUEUE_TRANSMIT, queue_num)?;
+        let recv_queue = VirtQueue::new(&mut transport, QUEUE_RECEIVE, queue_num)?;
+        let send_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT, queue_num)?;
 
         transport.finish_init();
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn invalid_queue_size() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         // Size not a power of 2.
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 3).unwrap_err(),
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn queue_too_big() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 5).unwrap_err(),
             Error::InvalidParam
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn queue_already_used() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap_err(),
@@ -306,14 +306,14 @@ mod tests {
 
     #[test]
     fn add_empty() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.add(&[], &[]).unwrap_err(), Error::InvalidParam);
     }
 
     #[test]
     fn add_too_big() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.available_desc(), 4);
         assert_eq!(
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn add_buffers() {
-        let mut header = VirtIOHeader::make_fake_header(0, 0, 0, 4);
+        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.size(), 4);
         assert_eq!(queue.available_desc(), 4);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn invalid_queue_size() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         // Size not a power of 2.
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 3).unwrap_err(),
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn queue_too_big() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 5).unwrap_err(),
             Error::InvalidParam
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn queue_already_used() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap_err(),
@@ -306,14 +306,14 @@ mod tests {
 
     #[test]
     fn add_empty() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.add(&[], &[]).unwrap_err(), Error::InvalidParam);
     }
 
     #[test]
     fn add_too_big() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.available_desc(), 4);
         assert_eq!(
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn add_buffers() {
-        let mut header = LegacyMmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
         let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
         assert_eq!(queue.size(), 4);
         assert_eq!(queue.available_desc(), 4);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -273,48 +273,54 @@ struct UsedElem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hal::fake::FakeHal;
+    use crate::{hal::fake::FakeHal, transport::mmio::MODERN_VERSION};
+    use core::ptr::NonNull;
 
     #[test]
     fn invalid_queue_size() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
         // Size not a power of 2.
         assert_eq!(
-            VirtQueue::<FakeHal>::new(&mut header, 0, 3).unwrap_err(),
+            VirtQueue::<FakeHal>::new(&mut transport, 0, 3).unwrap_err(),
             Error::InvalidParam
         );
     }
 
     #[test]
     fn queue_too_big() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
         assert_eq!(
-            VirtQueue::<FakeHal>::new(&mut header, 0, 5).unwrap_err(),
+            VirtQueue::<FakeHal>::new(&mut transport, 0, 5).unwrap_err(),
             Error::InvalidParam
         );
     }
 
     #[test]
     fn queue_already_used() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
-        VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(
-            VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap_err(),
+            VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap_err(),
             Error::AlreadyUsed
         );
     }
 
     #[test]
     fn add_empty() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
-        let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.add(&[], &[]).unwrap_err(), Error::InvalidParam);
     }
 
     #[test]
     fn add_too_big() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
-        let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.available_desc(), 4);
         assert_eq!(
             queue
@@ -326,8 +332,9 @@ mod tests {
 
     #[test]
     fn add_buffers() {
-        let mut header = MmioTransport::make_fake_header(0, 0, 0, 4);
-        let mut queue = VirtQueue::<FakeHal>::new(&mut header, 0, 4).unwrap();
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.size(), 4);
         assert_eq!(queue.available_desc(), 4);
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@ use core::slice;
 use core::sync::atomic::{fence, Ordering};
 
 use super::*;
-use crate::header::VirtIOHeader;
+use crate::transport::{mmio::VirtIOHeader, Transport};
 use bitflags::*;
 
 use volatile::Volatile;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -278,8 +278,8 @@ mod tests {
 
     #[test]
     fn invalid_queue_size() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         // Size not a power of 2.
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut transport, 0, 3).unwrap_err(),
@@ -289,8 +289,8 @@ mod tests {
 
     #[test]
     fn queue_too_big() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut transport, 0, 5).unwrap_err(),
             Error::InvalidParam
@@ -299,8 +299,8 @@ mod tests {
 
     #[test]
     fn queue_already_used() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(
             VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap_err(),
@@ -310,16 +310,16 @@ mod tests {
 
     #[test]
     fn add_empty() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.add(&[], &[]).unwrap_err(), Error::InvalidParam);
     }
 
     #[test]
     fn add_too_big() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.available_desc(), 4);
         assert_eq!(
@@ -332,8 +332,8 @@ mod tests {
 
     #[test]
     fn add_buffers() {
-        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 0, 0, 0, 4);
-        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) };
+        let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
+        let mut transport = unsafe { MmioTransport::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal>::new(&mut transport, 0, 4).unwrap();
         assert_eq!(queue.size(), 4);
         assert_eq!(queue.available_desc(), 4);

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -2,6 +2,7 @@ use super::{DeviceStatus, DeviceType, Transport};
 use volatile::{ReadOnly, Volatile, WriteOnly};
 
 const MAGIC_VALUE: u32 = 0x7472_6976;
+const CONFIG_SPACE_OFFSET: usize = 0x100;
 
 /// MMIO Device Legacy Register Interface.
 ///
@@ -272,5 +273,3 @@ impl Transport for VirtIOHeader {
         }
     }
 }
-
-const CONFIG_SPACE_OFFSET: usize = 0x100;

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -166,11 +166,6 @@ impl VirtIOHeader {
         self.vendor_id.read()
     }
 
-    /// Get the pointer to config space (at offset 0x100)
-    pub fn config_space(&self) -> *mut u64 {
-        (self as *const _ as usize + CONFIG_SPACE_OFFSET) as _
-    }
-
     /// Constructs a fake virtio header for use in unit tests.
     #[cfg(test)]
     pub fn make_fake_header(
@@ -271,5 +266,9 @@ impl Transport for VirtIOHeader {
         } else {
             false
         }
+    }
+
+    fn config_space(&self) -> *mut u64 {
+        (self as *const _ as usize + CONFIG_SPACE_OFFSET) as _
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -429,7 +429,7 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn config_space(&self) -> *mut u64 {
-        (self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _
+    fn config_space(&self) -> NonNull<u64> {
+        NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap()
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -331,6 +331,7 @@ impl Transport for LegacyMmioTransport {
         );
         let align = PAGE_SIZE as u32;
         let pfn = (descriptors / PAGE_SIZE) as u32;
+        assert_eq!(pfn as usize * PAGE_SIZE, descriptors);
         self.0.queue_sel.write(queue);
         self.0.queue_num.write(size);
         self.0.legacy_queue_align.write(align);

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -46,7 +46,7 @@ pub struct VirtIOHeader {
     /// initialization, before any queues are used. This value should be a
     /// power of 2 and is used by the device to calculate the Guest address
     /// of the first queue page (see QueuePFN).
-    guest_page_size: WriteOnly<u32>,
+    legacy_guest_page_size: WriteOnly<u32>,
 
     /// Reserved
     __r2: ReadOnly<u32>,
@@ -79,7 +79,7 @@ pub struct VirtIOHeader {
     /// Writing to this register notifies the device about alignment boundary
     /// of the Used Ring in bytes. This value should be a power of 2 and
     /// applies to the queue selected by writing to QueueSel.
-    queue_align: WriteOnly<u32>,
+    legacy_queue_align: WriteOnly<u32>,
 
     /// Guest physical page number of the virtual queue
     ///
@@ -92,7 +92,7 @@ pub struct VirtIOHeader {
     /// number of the queue, therefore a value other than zero (0x0) means that
     /// the queue is in use. Both read and write accesses apply to the queue
     /// selected by writing to QueueSel.
-    queue_pfn: Volatile<u32>,
+    legacy_queue_pfn: Volatile<u32>,
 
     /// new interface only
     queue_ready: Volatile<u32>,
@@ -186,13 +186,13 @@ impl VirtIOHeader {
             __r1: Default::default(),
             driver_features: Default::default(),
             driver_features_sel: Default::default(),
-            guest_page_size: Default::default(),
+            legacy_guest_page_size: Default::default(),
             __r2: Default::default(),
             queue_sel: Default::default(),
             queue_num_max: ReadOnly::new(queue_num_max),
             queue_num: Default::default(),
-            queue_align: Default::default(),
-            queue_pfn: Default::default(),
+            legacy_queue_align: Default::default(),
+            legacy_queue_pfn: Default::default(),
             queue_ready: Default::default(),
             __r3: Default::default(),
             queue_notify: Default::default(),
@@ -245,7 +245,7 @@ impl Transport for VirtIOHeader {
     }
 
     fn set_guest_page_size(&mut self, guest_page_size: u32) {
-        self.guest_page_size.write(guest_page_size);
+        self.legacy_guest_page_size.write(guest_page_size);
     }
 
     fn queue_set(
@@ -270,13 +270,13 @@ impl Transport for VirtIOHeader {
         let pfn = (descriptors / PAGE_SIZE) as u32;
         self.queue_sel.write(queue);
         self.queue_num.write(size);
-        self.queue_align.write(align);
-        self.queue_pfn.write(pfn);
+        self.legacy_queue_align.write(align);
+        self.legacy_queue_pfn.write(pfn);
     }
 
     fn queue_used(&mut self, queue: u32) -> bool {
         self.queue_sel.write(queue);
-        self.queue_pfn.read() != 0
+        self.legacy_queue_pfn.read() != 0
     }
 
     fn ack_interrupt(&mut self) -> bool {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,0 +1,119 @@
+pub mod mmio;
+
+use crate::PAGE_SIZE;
+use bitflags::bitflags;
+
+/// A VirtIO transport layer.
+pub trait Transport {
+    /// Reads device features.
+    fn read_device_features(&mut self) -> u64;
+
+    /// Writes device features.
+    fn write_driver_features(&mut self, driver_features: u64);
+
+    /// Gets the max size of queue.
+    fn max_queue_size(&self) -> u32;
+
+    /// Notifies the given queue on the device.
+    fn notify(&mut self, queue: u32);
+
+    /// Sets the device status.
+    fn set_status(&mut self, status: DeviceStatus);
+
+    /// Sets the guest page size.
+    fn set_guest_page_size(&mut self, guest_page_size: u32);
+
+    /// Sets up the given queue.
+    fn queue_set(&mut self, queue: u32, size: u32, align: u32, pfn: u32);
+
+    /// Gets the guest physical page number of the given virtual queue.
+    fn queue_physical_page_number(&mut self, queue: u32) -> u32;
+
+    /// Acknowledges an interrupt.
+    ///
+    /// Returns true on success.
+    fn ack_interrupt(&mut self) -> bool;
+
+    /// Begins initializing the device.
+    ///
+    /// Ref: virtio 3.1.1 Device Initialization
+    fn begin_init(&mut self, negotiate_features: impl FnOnce(u64) -> u64) {
+        self.set_status(DeviceStatus::ACKNOWLEDGE);
+        self.set_status(DeviceStatus::DRIVER);
+
+        let features = self.read_device_features();
+        self.write_driver_features(negotiate_features(features));
+        self.set_status(DeviceStatus::FEATURES_OK);
+
+        self.set_guest_page_size(PAGE_SIZE as u32);
+    }
+
+    /// Finishes initializing the device.
+    fn finish_init(&mut self) {
+        self.set_status(DeviceStatus::DRIVER_OK);
+    }
+
+    /// Returns whether the queue is in use, i.e. has a nonzero PFN.
+    fn queue_used(&mut self, queue: u32) -> bool {
+        self.queue_physical_page_number(queue) != 0
+    }
+}
+
+bitflags! {
+    /// The device status field.
+    pub struct DeviceStatus: u32 {
+        /// Indicates that the guest OS has found the device and recognized it
+        /// as a valid virtio device.
+        const ACKNOWLEDGE = 1;
+
+        /// Indicates that the guest OS knows how to drive the device.
+        const DRIVER = 2;
+
+        /// Indicates that something went wrong in the guest, and it has given
+        /// up on the device. This could be an internal error, or the driver
+        /// didn’t like the device for some reason, or even a fatal error
+        /// during device operation.
+        const FAILED = 128;
+
+        /// Indicates that the driver has acknowledged all the features it
+        /// understands, and feature negotiation is complete.
+        const FEATURES_OK = 8;
+
+        /// Indicates that the driver is set up and ready to drive the device.
+        const DRIVER_OK = 4;
+
+        /// Indicates that the device has experienced an error from which it
+        /// can’t recover.
+        const DEVICE_NEEDS_RESET = 64;
+    }
+}
+
+/// Types of virtio devices.
+#[repr(u8)]
+#[derive(Debug, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub enum DeviceType {
+    Invalid = 0,
+    Network = 1,
+    Block = 2,
+    Console = 3,
+    EntropySource = 4,
+    MemoryBallooning = 5,
+    IoMemory = 6,
+    Rpmsg = 7,
+    ScsiHost = 8,
+    _9P = 9,
+    Mac80211 = 10,
+    RprocSerial = 11,
+    VirtioCAIF = 12,
+    MemoryBalloon = 13,
+    GPU = 16,
+    Timer = 17,
+    Input = 18,
+    Socket = 19,
+    Crypto = 20,
+    SignalDistributionModule = 21,
+    Pstore = 22,
+    IOMMU = 23,
+    Memory = 24,
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,6 +2,7 @@ pub mod mmio;
 
 use crate::{PhysAddr, PAGE_SIZE};
 use bitflags::bitflags;
+use core::ptr::NonNull;
 
 /// A VirtIO transport layer.
 pub trait Transport {
@@ -64,7 +65,7 @@ pub trait Transport {
     }
 
     /// Gets the pointer to the config space.
-    fn config_space(&self) -> *mut u64;
+    fn config_space(&self) -> NonNull<u64>;
 }
 
 bitflags! {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,6 +5,9 @@ use bitflags::bitflags;
 
 /// A VirtIO transport layer.
 pub trait Transport {
+    /// Gets the device type.
+    fn device_type(&self) -> DeviceType;
+
     /// Reads device features.
     fn read_device_features(&mut self) -> u64;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -57,6 +57,9 @@ pub trait Transport {
     fn queue_used(&mut self, queue: u32) -> bool {
         self.queue_physical_page_number(queue) != 0
     }
+
+    /// Gets the pointer to the config space.
+    fn config_space(&self) -> *mut u64;
 }
 
 bitflags! {


### PR DESCRIPTION
This PR makes a bunch of changes around the VirtIO transport implementation.

* I've added a new `Transport` trait. This currently only has one implementation (for the MMIO transport) but I plan to add a PCI implementation in a future PR.
* I've added support for the modern MMIO transport (version 2) in addition to the legacy one (version 1). Initially I did this as two separate implementations of `Transport`, but this turned out to be rather cumbersome to use so I've gone for a single implementation that stores the version and checks it as needed at runtime. This is only relevant during initialisation, so shouldn't have a significant runtime cost.
* As part of the above, I made the new `MmioTransport` wrap a `NonNull` pointer to the `VirtIOHeader` rather than having the caller create a mutable reference to it. I'm still not entirely convinced that the way this crate uses references is sound, and will think about that some more, but I think this is a step in the right direction at least.