### PR TITLE
Use actual GPU resolution in example rather than hardcoding.

### DIFF
--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -100,10 +100,14 @@ fn virtio_blk<T: Transport>(transport: T) {
 
 fn virtio_gpu<T: Transport>(transport: T) {
     let mut gpu = VirtIOGpu::<HalImpl, T>::new(transport).expect("failed to create gpu driver");
+    let (width, height) = gpu.resolution().expect("failed to get resolution");
+    let width = width as usize;
+    let height = height as usize;
+    info!("GPU resolution is {}x{}", width, height);
     let fb = gpu.setup_framebuffer().expect("failed to get fb");
-    for y in 0..768 {
-        for x in 0..1024 {
-            let idx = (y * 1024 + x) * 4;
+    for y in 0..height {
+        for x in 0..width {
+            let idx = (y * width + x) * 4;
             fb[idx] = x as u8;
             fb[idx + 1] = y as u8;
             fb[idx + 2] = (x + y) as u8;


### PR DESCRIPTION
Different versions of QEMU seem to have different default resolutions, so it was crashing due to an array access out of bounds.