### PR TITLE
Fix soundness issues with MMIO and shared memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,5 @@ description = "VirtIO guest drivers."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-volatile = "0.3"
 log = "0.4"
 bitflags = "1.3"

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -10,13 +10,13 @@ use log::*;
 ///
 /// Read and write requests (and other exotic requests) are placed in the queue,
 /// and serviced (probably out of order) by the device except where noted.
-pub struct VirtIOBlk<'a, H: Hal, T: Transport> {
+pub struct VirtIOBlk<H: Hal, T: Transport> {
     transport: T,
-    queue: VirtQueue<'a, H>,
+    queue: VirtQueue<H>,
     capacity: usize,
 }
 
-impl<H: Hal, T: Transport> VirtIOBlk<'_, H, T> {
+impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// Create a new VirtIO-Blk driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
+use ::volatile::Volatile;
 use bitflags::*;
 use core::hint::spin_loop;
 use log::*;
-use volatile::Volatile;
 
 /// The virtio block device is a simple virtual block device (ie. disk).
 ///

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use ::volatile::{ReadOnly, WriteOnly};
+use crate::volatile::{ReadOnly, WriteOnly};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
@@ -161,7 +161,7 @@ mod tests {
             cols: ReadOnly::new(0),
             rows: ReadOnly::new(0),
             max_nr_ports: ReadOnly::new(0),
-            emerg_wr: WriteOnly::new(0),
+            emerg_wr: WriteOnly::default(),
         };
         let state = Arc::new(Mutex::new(State {
             status: DeviceStatus::empty(),

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
+use ::volatile::{ReadOnly, WriteOnly};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
-use volatile::{ReadOnly, WriteOnly};
 
 const QUEUE_RECEIVEQ_PORT_0: usize = 0;
 const QUEUE_TRANSMITQ_PORT_0: usize = 1;

--- a/src/console.rs
+++ b/src/console.rs
@@ -14,8 +14,8 @@ const QUEUE_SIZE: u16 = 2;
 /// Emergency and cols/rows unimplemented.
 pub struct VirtIOConsole<'a, H: Hal, T: Transport> {
     transport: T,
-    receiveq: VirtQueue<'a, H>,
-    transmitq: VirtQueue<'a, H>,
+    receiveq: VirtQueue<H>,
+    transmitq: VirtQueue<H>,
     queue_buf_dma: DMA<H>,
     queue_buf_rx: &'a mut [u8],
     cursor: usize,

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
+use ::volatile::{ReadOnly, Volatile, WriteOnly};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
-use volatile::{ReadOnly, Volatile, WriteOnly};
 
 /// A virtio based graphics adapter.
 ///

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -21,9 +21,9 @@ pub struct VirtIOGpu<'a, H: Hal, T: Transport> {
     /// DMA area of cursor image buffer.
     cursor_buffer_dma: Option<DMA<H>>,
     /// Queue for sending control commands.
-    control_queue: VirtQueue<'a, H>,
+    control_queue: VirtQueue<H>,
     /// Queue for sending cursor commands.
-    cursor_queue: VirtQueue<'a, H>,
+    cursor_queue: VirtQueue<H>,
     /// Queue buffer DMA
     queue_buf_dma: DMA<H>,
     /// Send buffer for queue.

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use ::volatile::{ReadOnly, Volatile, WriteOnly};
+use crate::volatile::{ReadOnly, Volatile, WriteOnly};
 use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;

--- a/src/input.rs
+++ b/src/input.rs
@@ -10,14 +10,14 @@ use log::*;
 /// An instance of the virtio device represents one such input device.
 /// Device behavior mirrors that of the evdev layer in Linux,
 /// making pass-through implementations on top of evdev easy.
-pub struct VirtIOInput<'a, H: Hal, T: Transport> {
+pub struct VirtIOInput<H: Hal, T: Transport> {
     transport: T,
-    event_queue: VirtQueue<'a, H>,
-    status_queue: VirtQueue<'a, H>,
+    event_queue: VirtQueue<H>,
+    status_queue: VirtQueue<H>,
     event_buf: Box<[InputEvent; 32]>,
 }
 
-impl<H: Hal, T: Transport> VirtIOInput<'_, H, T> {
+impl<H: Hal, T: Transport> VirtIOInput<H, T> {
     /// Create a new VirtIO-Input driver.
     pub fn new(mut transport: T) -> Result<Self> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::transport::Transport;
+use ::volatile::{ReadOnly, WriteOnly};
 use alloc::boxed::Box;
 use bitflags::*;
 use log::*;
-use volatile::{ReadOnly, WriteOnly};
 
 /// Virtual human interface devices such as keyboards, mice and tablets.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod input;
 mod net;
 mod queue;
 mod transport;
+mod volatile;
 
 pub use self::blk::{BlkResp, RespStatus, VirtIOBlk};
 pub use self::console::VirtIOConsole;

--- a/src/net.rs
+++ b/src/net.rs
@@ -2,10 +2,10 @@ use core::mem::{size_of, MaybeUninit};
 
 use super::*;
 use crate::transport::Transport;
+use ::volatile::{ReadOnly, Volatile};
 use bitflags::*;
 use core::hint::spin_loop;
 use log::*;
-use volatile::{ReadOnly, Volatile};
 
 /// The virtio network device is a virtual ethernet card.
 ///

--- a/src/net.rs
+++ b/src/net.rs
@@ -14,14 +14,14 @@ use log::*;
 /// Empty buffers are placed in one virtqueue for receiving packets, and
 /// outgoing packets are enqueued into another for transmission in that order.
 /// A third command queue is used to control advanced filtering features.
-pub struct VirtIONet<'a, H: Hal, T: Transport> {
+pub struct VirtIONet<H: Hal, T: Transport> {
     transport: T,
     mac: EthernetAddress,
-    recv_queue: VirtQueue<'a, H>,
-    send_queue: VirtQueue<'a, H>,
+    recv_queue: VirtQueue<H>,
+    send_queue: VirtQueue<H>,
 }
 
-impl<H: Hal, T: Transport> VirtIONet<'_, H, T> {
+impl<H: Hal, T: Transport> VirtIONet<H, T> {
     /// Create a new VirtIO-Net driver.
     pub fn new(mut transport: T) -> Result<Self> {
         transport.begin_init(|features| {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,7 +8,7 @@ use super::*;
 use crate::transport::Transport;
 use bitflags::*;
 
-use volatile::Volatile;
+use ::volatile::Volatile;
 
 /// The mechanism for bulk data transport on virtio devices.
 ///

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -22,7 +22,7 @@ pub struct VirtQueue<'a, H: Hal> {
     /// Available ring
     avail: &'a mut AvailRing,
     /// Used ring
-    used: &'a mut UsedRing,
+    used: &'a UsedRing,
 
     /// The index of queue
     queue_idx: u32,

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -1,0 +1,76 @@
+/// An MMIO register which can only be read from.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub struct ReadOnly<T: Copy>(T);
+
+impl<T: Copy> ReadOnly<T> {
+    pub const fn new(value: T) -> Self {
+        Self(value)
+    }
+}
+
+/// An MMIO register which can only be written to.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub struct WriteOnly<T: Copy>(T);
+
+/// An MMIO register which may be both read and written.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub struct Volatile<T: Copy>(T);
+
+impl<T: Copy> Volatile<T> {
+    pub const fn new(value: T) -> Self {
+        Self(value)
+    }
+}
+
+pub trait VolatileReadable<T> {
+    unsafe fn vread(self) -> T;
+}
+
+impl<T: Copy> VolatileReadable<T> for *const ReadOnly<T> {
+    unsafe fn vread(self) -> T {
+        self.read_volatile().0
+    }
+}
+
+impl<T: Copy> VolatileReadable<T> for *const Volatile<T> {
+    unsafe fn vread(self) -> T {
+        self.read_volatile().0
+    }
+}
+
+pub trait VolatileWritable<T> {
+    unsafe fn vwrite(self, value: T);
+}
+
+impl<T: Copy> VolatileWritable<T> for *mut WriteOnly<T> {
+    unsafe fn vwrite(self, value: T) {
+        (self as *mut T).write_volatile(value)
+    }
+}
+
+impl<T: Copy> VolatileWritable<T> for *mut Volatile<T> {
+    unsafe fn vwrite(self, value: T) {
+        (self as *mut T).write_volatile(value)
+    }
+}
+
+macro_rules! volread {
+    ($nonnull:expr, $field:ident) => {
+        $crate::volatile::VolatileReadable::vread(core::ptr::addr_of!((*$nonnull.as_ptr()).$field))
+    };
+}
+
+macro_rules! volwrite {
+    ($nonnull:expr, $field:ident, $value:expr) => {
+        $crate::volatile::VolatileWritable::vwrite(
+            core::ptr::addr_of_mut!((*$nonnull.as_ptr()).$field),
+            $value,
+        )
+    };
+}
+
+pub(crate) use volread;
+pub(crate) use volwrite;

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -4,7 +4,7 @@
 pub struct ReadOnly<T: Copy>(T);
 
 impl<T: Copy> ReadOnly<T> {
-    pub const fn new(value: T) -> Self {
+    pub fn new(value: T) -> Self {
         Self(value)
     }
 }
@@ -20,7 +20,7 @@ pub struct WriteOnly<T: Copy>(T);
 pub struct Volatile<T: Copy>(T);
 
 impl<T: Copy> Volatile<T> {
-    pub const fn new(value: T) -> Self {
+    pub fn new(value: T) -> Self {
         Self(value)
     }
 }


### PR DESCRIPTION
The way the `volatile` crate handles MMIO regions is not sound, because it creates references to memory which shouldn't be considered dereferenceable. There is an attempt to fix this in https://github.com/rust-osdev/volatile/pull/22 (and lots of discussion), but that PR has been open since May 2021 and doesn't seem near being submitted. Instead, I've implemented the functionality we need in a new `volatile` module here using the `addr_of!` and `addr_of_mut!` macros, keeping all MMIO regions as pointers and never creating references.

This works for the MMIO transport and config regions. For the Virtqueue, I don't think we need volatile access at all because it's just shared memory, not MMIO. We still shouldn't be using references, however, as DMA to these shared regions by the device violates Rust's aliasing rules, so I've changed the implementation to use pointers instead.