### PR TITLE
Add PCI transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ VirtIO guest drivers in Rust. For **no_std** environment.
 
 - x86_64 (TODO)
 
+- [aarch64](./examples/aarch64)
 - [RISCV](./examples/riscv)

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ VirtIO guest drivers in Rust. For **no_std** environment.
 
 ### Transports
 
-| Transport   | Supported |           |
-| ----------- | --------- | --------- |
-| Legacy MMIO | ✅        | version 1 |
-| MMIO        | ✅        | version 2 |
-| PCI         | ❌        |           |
+| Transport   | Supported |                                                   |
+| ----------- | --------- | ------------------------------------------------- |
+| Legacy MMIO | ✅        | version 1                                         |
+| MMIO        | ✅        | version 2                                         |
+| PCI         | ✅        | Memory-mapped CAM only, e.g. aarch64 or PCIe ECAM |
 
 ### Device-independent features
 

--- a/examples/aarch64/Makefile
+++ b/examples/aarch64/Makefile
@@ -44,9 +44,22 @@ qemu: $(kernel_bin) $(img)
 		-serial mon:stdio \
 		-kernel $(kernel_bin) \
 		-global virtio-mmio.force-legacy=false \
+		-nic none \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
 		-device virtio-gpu-device
+
+qemu-pci: $(kernel_bin) $(img)
+	qemu-system-aarch64 \
+		-machine virt \
+		-cpu max \
+		-serial mon:stdio \
+		-kernel $(kernel_bin) \
+		-nic none \
+		-drive file=$(img),if=none,format=raw,id=x0 \
+		-device virtio-blk-pci,drive=x0 \
+		-device virtio-gpu-pci \
+		-device virtio-serial,id=virtio-serial0
 
 $(img):
 	dd if=/dev/zero of=$@ bs=512 count=32

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -187,7 +187,12 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
                 dump_bar_contents(&mut pci_root, device_function, 4);
                 let mut transport =
                     PciTransport::new::<HalImpl>(pci_root.clone(), device_function).unwrap();
-                info!("  Features: {:#018x}", transport.read_device_features());
+                info!(
+                    "Detected virtio PCI device with device type {:?}, features {:#018x}",
+                    transport.device_type(),
+                    transport.read_device_features(),
+                );
+                virtio_device(transport);
             }
         }
     }

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -263,13 +263,23 @@ fn allocate_bars(
             address_type, size, ..
         } = info
         {
-            if address_type != MemoryBarType::Width32 {
-                panic!("Memory BAR address type {:?} not supported.", address_type);
-            }
-            if size > 0 {
-                let address = allocator.allocate_memory_32(size);
-                debug!("Allocated address {:#010x}", address);
-                root.set_bar_32(device_function, bar_index, address);
+            match address_type {
+                MemoryBarType::Width32 => {
+                    if size > 0 {
+                        let address = allocator.allocate_memory_32(size);
+                        debug!("Allocated address {:#010x}", address);
+                        root.set_bar_32(device_function, bar_index, address);
+                    }
+                }
+                MemoryBarType::Width64 => {
+                    if size > 0 {
+                        let address = allocator.allocate_memory_32(size);
+                        debug!("Allocated address {:#010x}", address);
+                        root.set_bar_64(device_function, bar_index, address.into());
+                    }
+                }
+
+                _ => panic!("Memory BAR address type {:?} not supported.", address_type),
             }
         }
 

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -14,7 +14,7 @@ use psci::system_off;
 use virtio_drivers::{
     pci::{
         bus::{Cam, PciRoot},
-        virtio_device_type,
+        virtio_device_type, PciTransport,
     },
     DeviceType, MmioTransport, Transport, VirtIOBlk, VirtIOGpu, VirtIOHeader, VirtIONet,
 };
@@ -157,6 +157,9 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
             );
             if let Some(virtio_type) = virtio_device_type(&info) {
                 info!("  VirtIO {:?}", virtio_type);
+                let mut transport =
+                    PciTransport::new::<HalImpl>(pci_root.clone(), device_function).unwrap();
+                info!("  Features: {:#018x}", transport.read_device_features());
             }
         }
     }

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -186,7 +186,7 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
                 allocate_bars(&mut pci_root, device_function, &mut allocator);
                 dump_bar_contents(&mut pci_root, device_function, 4);
                 let mut transport =
-                    PciTransport::new::<HalImpl>(pci_root.clone(), device_function).unwrap();
+                    PciTransport::new::<HalImpl>(&mut pci_root, device_function).unwrap();
                 info!(
                     "Detected virtio PCI device with device type {:?}, features {:#018x}",
                     transport.device_type(),

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -150,7 +150,11 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
         // Safe because we know the pointer is to a valid MMIO region.
         let mut pci_root = unsafe { PciRoot::new(region.starting_address as *mut u8, cam) };
         for (device_function, info) in pci_root.enumerate_bus(0) {
-            info!("Found {} at {}", info, device_function);
+            let (status, command) = pci_root.get_status_command(device_function);
+            info!(
+                "Found {} at {}, status {:?} command {:?}",
+                info, device_function, status, command
+            );
             if let Some(virtio_type) = virtio_device_type(&info) {
                 info!("  VirtIO {:?}", virtio_type);
             }

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -173,6 +173,7 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
             region.starting_address,
             region.starting_address as usize + region.size.unwrap()
         );
+        assert_eq!(region.size.unwrap(), cam.size() as usize);
         // Safe because we know the pointer is to a valid MMIO region.
         let mut pci_root = unsafe { PciRoot::new(region.starting_address as *mut u8, cam) };
         for (device_function, info) in pci_root.enumerate_bus(0) {

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -318,6 +318,11 @@ fn allocate_bars(
         device_function,
         Command::IO_SPACE | Command::MEMORY_SPACE | Command::BUS_MASTER,
     );
+    let (status, command) = root.get_status_command(device_function);
+    debug!(
+        "Allocated BARs and enabled device, status {:?} command {:?}",
+        status, command
+    );
 }
 
 #[panic_handler]

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -12,7 +12,10 @@ use hal::HalImpl;
 use log::{debug, error, info, trace, warn, LevelFilter};
 use psci::system_off;
 use virtio_drivers::{
-    pci::bus::{Cam, PciRoot},
+    pci::{
+        bus::{Cam, PciRoot},
+        virtio_device_type,
+    },
     DeviceType, MmioTransport, Transport, VirtIOBlk, VirtIOGpu, VirtIOHeader, VirtIONet,
 };
 
@@ -148,6 +151,9 @@ fn enumerate_pci(pci_node: FdtNode, cam: Cam) {
         let mut pci_root = unsafe { PciRoot::new(region.starting_address as *mut u8, cam) };
         for (device_function, info) in pci_root.enumerate_bus(0) {
             info!("Found {} at {}", info, device_function);
+            if let Some(virtio_type) = virtio_device_type(&info) {
+                info!("  VirtIO {:?}", virtio_type);
+            }
         }
     }
 }

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -185,7 +185,6 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
 }
 
 #[repr(C)]
-#[derive(Debug)]
 struct BlkConfig {
     /// Number of 512 Bytes sectors
     capacity: Volatile<u64>,

--- a/src/console.rs
+++ b/src/console.rs
@@ -6,8 +6,8 @@ use bitflags::*;
 use core::{fmt, hint::spin_loop};
 use log::*;
 
-const QUEUE_RECEIVEQ_PORT_0: usize = 0;
-const QUEUE_TRANSMITQ_PORT_0: usize = 1;
+const QUEUE_RECEIVEQ_PORT_0: u16 = 0;
+const QUEUE_TRANSMITQ_PORT_0: u16 = 1;
 const QUEUE_SIZE: u16 = 2;
 
 /// Virtio console. Only one single port is allowed since ``alloc'' is disabled.
@@ -93,7 +93,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
     pub fn send(&mut self, chr: u8) -> Result<()> {
         let buf: [u8; 1] = [chr];
         self.transmitq.add(&[&buf], &[])?;
-        self.transport.notify(QUEUE_TRANSMITQ_PORT_0 as u32);
+        self.transport.notify(QUEUE_TRANSMITQ_PORT_0);
         while !self.transmitq.can_pop() {
             spin_loop();
         }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use crate::volatile::{ReadOnly, WriteOnly};
+use crate::volatile::{volread, ReadOnly, WriteOnly};
 use bitflags::*;
-use core::{fmt, hint::spin_loop};
+use core::hint::spin_loop;
 use log::*;
 
 const QUEUE_RECEIVEQ_PORT_0: u16 = 0;
@@ -32,8 +32,15 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
             (features & supported_features).bits()
         });
         let config_space = transport.config_space().cast::<Config>();
-        let config = unsafe { config_space.as_ref() };
-        info!("Config: {:?}", config);
+        unsafe {
+            let columns = volread!(config_space, cols);
+            let rows = volread!(config_space, rows);
+            let max_ports = volread!(config_space, max_nr_ports);
+            info!(
+                "Columns: {} Rows: {} Max ports: {}",
+                columns, rows, max_ports,
+            );
+        }
         let receiveq = VirtQueue::new(&mut transport, QUEUE_RECEIVEQ_PORT_0, QUEUE_SIZE)?;
         let transmitq = VirtQueue::new(&mut transport, QUEUE_TRANSMITQ_PORT_0, QUEUE_SIZE)?;
         let queue_buf_dma = DMA::new(1)?;
@@ -108,16 +115,6 @@ struct Config {
     rows: ReadOnly<u16>,
     max_nr_ports: ReadOnly<u32>,
     emerg_wr: WriteOnly<u32>,
-}
-
-impl fmt::Debug for Config {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Config")
-            .field("cols", &self.cols)
-            .field("rows", &self.rows)
-            .field("max_nr_ports", &self.max_nr_ports)
-            .finish()
-    }
 }
 
 bitflags! {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -165,7 +165,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         }
         self.control_queue
             .add(&[self.queue_buf_send], &[self.queue_buf_recv])?;
-        self.transport.notify(QUEUE_TRANSMIT as u32);
+        self.transport.notify(QUEUE_TRANSMIT);
         while !self.control_queue.can_pop() {
             spin_loop();
         }
@@ -179,7 +179,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
             (self.queue_buf_send.as_mut_ptr() as *mut Req).write(req);
         }
         self.cursor_queue.add(&[self.queue_buf_send], &[])?;
-        self.transport.notify(QUEUE_CURSOR as u32);
+        self.transport.notify(QUEUE_CURSOR);
         while !self.cursor_queue.can_pop() {
             spin_loop();
         }
@@ -483,8 +483,8 @@ struct UpdateCursor {
     _padding: u32,
 }
 
-const QUEUE_TRANSMIT: usize = 0;
-const QUEUE_CURSOR: usize = 1;
+const QUEUE_TRANSMIT: u16 = 0;
+const QUEUE_CURSOR: u16 = 1;
 
 const SCANOUT_ID: u32 = 0;
 const RESOURCE_ID_FB: u32 = 0xbabe;

--- a/src/input.rs
+++ b/src/input.rs
@@ -178,8 +178,8 @@ bitflags! {
     }
 }
 
-const QUEUE_EVENT: usize = 0;
-const QUEUE_STATUS: usize = 1;
+const QUEUE_EVENT: u16 = 0;
+const QUEUE_STATUS: u16 = 1;
 
 // a parameter that can change
 const QUEUE_SIZE: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use self::input::{InputConfigSelect, InputEvent, VirtIOInput};
 pub use self::net::VirtIONet;
 use self::queue::VirtQueue;
 pub use self::transport::mmio::{MmioError, MmioTransport, MmioVersion, VirtIOHeader};
+pub use self::transport::pci;
 pub use self::transport::{DeviceStatus, DeviceType, Transport};
 use core::mem::size_of;
 use hal::*;

--- a/src/net.rs
+++ b/src/net.rs
@@ -177,7 +177,6 @@ bitflags! {
 }
 
 #[repr(C)]
-#[derive(Debug)]
 struct Config {
     mac: ReadOnly<EthernetAddress>,
     status: ReadOnly<Status>,

--- a/src/net.rs
+++ b/src/net.rs
@@ -78,7 +78,7 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
         let mut header = MaybeUninit::<Header>::uninit();
         let header_buf = unsafe { (*header.as_mut_ptr()).as_buf_mut() };
         self.recv_queue.add(&[], &[header_buf, buf])?;
-        self.transport.notify(QUEUE_RECEIVE as u32);
+        self.transport.notify(QUEUE_RECEIVE);
         while !self.recv_queue.can_pop() {
             spin_loop();
         }
@@ -92,7 +92,7 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
     pub fn send(&mut self, buf: &[u8]) -> Result {
         let header = unsafe { MaybeUninit::<Header>::zeroed().assume_init() };
         self.send_queue.add(&[header.as_buf(), buf], &[])?;
-        self.transport.notify(QUEUE_TRANSMIT as u32);
+        self.transport.notify(QUEUE_TRANSMIT);
         while !self.send_queue.can_pop() {
             spin_loop();
         }
@@ -218,5 +218,5 @@ enum GsoType {
     ECN = 0x80,
 }
 
-const QUEUE_RECEIVE: usize = 0;
-const QUEUE_TRANSMIT: usize = 1;
+const QUEUE_RECEIVE: u16 = 0;
+const QUEUE_TRANSMIT: u16 = 1;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -39,8 +39,8 @@ pub struct VirtQueue<H: Hal> {
 
 impl<H: Hal> VirtQueue<H> {
     /// Create a new VirtQueue.
-    pub fn new<T: Transport>(transport: &mut T, idx: usize, size: u16) -> Result<Self> {
-        if transport.queue_used(idx as u32) {
+    pub fn new<T: Transport>(transport: &mut T, idx: u16, size: u16) -> Result<Self> {
+        if transport.queue_used(idx) {
             return Err(Error::AlreadyUsed);
         }
         if !size.is_power_of_two() || transport.max_queue_size() < size as u32 {
@@ -51,7 +51,7 @@ impl<H: Hal> VirtQueue<H> {
         let dma = DMA::new(layout.size / PAGE_SIZE)?;
 
         transport.queue_set(
-            idx as u32,
+            idx,
             size as u32,
             dma.paddr(),
             dma.paddr() + layout.avail_offset,

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -34,7 +34,7 @@ impl Transport for FakeTransport {
         self.max_queue_size
     }
 
-    fn notify(&mut self, queue: u32) {
+    fn notify(&mut self, queue: u16) {
         self.state.lock().unwrap().queues[queue as usize].notified = true;
     }
 
@@ -48,7 +48,7 @@ impl Transport for FakeTransport {
 
     fn queue_set(
         &mut self,
-        queue: u32,
+        queue: u16,
         size: u32,
         descriptors: PhysAddr,
         driver_area: PhysAddr,
@@ -61,7 +61,7 @@ impl Transport for FakeTransport {
         state.queues[queue as usize].device_area = device_area;
     }
 
-    fn queue_used(&mut self, queue: u32) -> bool {
+    fn queue_used(&mut self, queue: u16) -> bool {
         self.state.lock().unwrap().queues[queue as usize].descriptors != 0
     }
 
@@ -92,8 +92,8 @@ impl State {
     /// Simulates the device writing to the given queue.
     ///
     /// The fake device always uses descriptors in order.
-    pub fn write_to_queue(&mut self, queue_size: u16, queue_index: usize, data: &[u8]) {
-        let receive_queue = &self.queues[queue_index];
+    pub fn write_to_queue(&mut self, queue_size: u16, queue_index: u16, data: &[u8]) {
+        let receive_queue = &self.queues[queue_index as usize];
         assert_ne!(receive_queue.descriptors, 0);
         fake_write_to_queue(
             queue_size,

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -311,10 +311,8 @@ impl MmioTransport {
 impl Transport for MmioTransport {
     fn device_type(&self) -> DeviceType {
         // Safe because self.header points to a valid VirtIO MMIO region.
-        match unsafe { volread!(self.header, device_id) } {
-            x @ 1..=13 | x @ 16..=24 => unsafe { core::mem::transmute(x as u8) },
-            _ => DeviceType::Invalid,
-        }
+        let device_id = unsafe { volread!(self.header, device_id) };
+        device_id.into()
     }
 
     fn read_device_features(&mut self) -> u64 {

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -341,10 +341,10 @@ impl Transport for MmioTransport {
         unsafe { volread!(self.header, queue_num_max) }
     }
 
-    fn notify(&mut self, queue: u32) {
+    fn notify(&mut self, queue: u16) {
         // Safe because self.header points to a valid VirtIO MMIO region.
         unsafe {
-            volwrite!(self.header, queue_notify, queue);
+            volwrite!(self.header, queue_notify, queue.into());
         }
     }
 
@@ -371,7 +371,7 @@ impl Transport for MmioTransport {
 
     fn queue_set(
         &mut self,
-        queue: u32,
+        queue: u16,
         size: u32,
         descriptors: PhysAddr,
         driver_area: PhysAddr,
@@ -395,7 +395,7 @@ impl Transport for MmioTransport {
                 assert_eq!(pfn as usize * PAGE_SIZE, descriptors);
                 // Safe because self.header points to a valid VirtIO MMIO region.
                 unsafe {
-                    volwrite!(self.header, queue_sel, queue);
+                    volwrite!(self.header, queue_sel, queue.into());
                     volwrite!(self.header, queue_num, size);
                     volwrite!(self.header, legacy_queue_align, align);
                     volwrite!(self.header, legacy_queue_pfn, pfn);
@@ -404,7 +404,7 @@ impl Transport for MmioTransport {
             MmioVersion::Modern => {
                 // Safe because self.header points to a valid VirtIO MMIO region.
                 unsafe {
-                    volwrite!(self.header, queue_sel, queue);
+                    volwrite!(self.header, queue_sel, queue.into());
                     volwrite!(self.header, queue_num, size);
                     volwrite!(self.header, queue_desc_low, descriptors as u32);
                     volwrite!(self.header, queue_desc_high, (descriptors >> 32) as u32);
@@ -418,10 +418,10 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn queue_used(&mut self, queue: u32) -> bool {
+    fn queue_used(&mut self, queue: u16) -> bool {
         // Safe because self.header points to a valid VirtIO MMIO region.
         unsafe {
-            volwrite!(self.header, queue_sel, queue);
+            volwrite!(self.header, queue_sel, queue.into());
             match self.version {
                 MmioVersion::Legacy => volread!(self.header, legacy_queue_pfn) != 0,
                 MmioVersion::Modern => volread!(self.header, queue_ready) != 0,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 pub mod fake;
 pub mod mmio;
+pub mod pci;
 
 use crate::{PhysAddr, PAGE_SIZE};
 use bitflags::bitflags;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -135,3 +135,45 @@ pub enum DeviceType {
     IOMMU = 23,
     Memory = 24,
 }
+
+impl From<u32> for DeviceType {
+    fn from(virtio_device_id: u32) -> Self {
+        match virtio_device_id {
+            1 => DeviceType::Network,
+            2 => DeviceType::Block,
+            3 => DeviceType::Console,
+            4 => DeviceType::EntropySource,
+            5 => DeviceType::MemoryBalloon,
+            6 => DeviceType::IoMemory,
+            7 => DeviceType::Rpmsg,
+            8 => DeviceType::ScsiHost,
+            9 => DeviceType::_9P,
+            10 => DeviceType::Mac80211,
+            11 => DeviceType::RprocSerial,
+            12 => DeviceType::VirtioCAIF,
+            13 => DeviceType::MemoryBalloon,
+            16 => DeviceType::GPU,
+            17 => DeviceType::Timer,
+            18 => DeviceType::Input,
+            19 => DeviceType::Socket,
+            20 => DeviceType::Crypto,
+            21 => DeviceType::SignalDistributionModule,
+            22 => DeviceType::Pstore,
+            23 => DeviceType::IOMMU,
+            24 => DeviceType::Memory,
+            _ => DeviceType::Invalid,
+        }
+    }
+}
+
+impl From<u16> for DeviceType {
+    fn from(virtio_device_id: u16) -> Self {
+        u32::from(virtio_device_id).into()
+    }
+}
+
+impl From<u8> for DeviceType {
+    fn from(virtio_device_id: u8) -> Self {
+        u32::from(virtio_device_id).into()
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -22,7 +22,7 @@ pub trait Transport {
     fn max_queue_size(&self) -> u32;
 
     /// Notifies the given queue on the device.
-    fn notify(&mut self, queue: u32);
+    fn notify(&mut self, queue: u16);
 
     /// Sets the device status.
     fn set_status(&mut self, status: DeviceStatus);
@@ -33,7 +33,7 @@ pub trait Transport {
     /// Sets up the given queue.
     fn queue_set(
         &mut self,
-        queue: u32,
+        queue: u16,
         size: u32,
         descriptors: PhysAddr,
         driver_area: PhysAddr,
@@ -41,7 +41,7 @@ pub trait Transport {
     );
 
     /// Returns whether the queue is in use, i.e. has a nonzero PFN or is marked as ready.
-    fn queue_used(&mut self, queue: u32) -> bool;
+    fn queue_used(&mut self, queue: u16) -> bool;
 
     /// Acknowledges an interrupt.
     ///

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -1,5 +1,7 @@
 //! PCI transport for VirtIO.
 
+pub mod bus;
+
 use super::DeviceType;
 
 /// The PCI vendor ID for VirtIO devices.

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -91,7 +91,7 @@ pub struct PciTransport {
     notify_region_size: usize,
     notify_off_multiplier: u32,
     /// The ISR status register within some BAR.
-    isr_status: NonNull<Volatile<u32>>,
+    isr_status: NonNull<Volatile<u8>>,
     /// The VirtIO device-specific configuration within some BAR.
     config_space: Option<NonNull<u64>>,
     /// The size of the VirtIO device-specific configuration region in bytes.

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -1,0 +1,52 @@
+//! PCI transport for VirtIO.
+
+use super::DeviceType;
+
+/// The PCI vendor ID for VirtIO devices.
+const VIRTIO_VENDOR_ID: u16 = 0x1af4;
+
+/// The offset to add to a VirtIO device ID to get the corresponding PCI device ID.
+const PCI_DEVICE_ID_OFFSET: u16 = 0x1040;
+
+const TRANSITIONAL_NETWORK: u16 = 0x1000;
+const TRANSITIONAL_BLOCK: u16 = 0x1001;
+const TRANSITIONAL_MEMORY_BALLOONING: u16 = 0x1002;
+const TRANSITIONAL_CONSOLE: u16 = 0x1003;
+const TRANSITIONAL_SCSI_HOST: u16 = 0x1004;
+const TRANSITIONAL_ENTROPY_SOURCE: u16 = 0x1005;
+const TRANSITIONAL_9P_TRANSPORT: u16 = 0x1009;
+
+fn device_type(pci_device_id: u16) -> DeviceType {
+    match pci_device_id {
+        TRANSITIONAL_NETWORK => DeviceType::Network,
+        TRANSITIONAL_BLOCK => DeviceType::Block,
+        TRANSITIONAL_MEMORY_BALLOONING => DeviceType::MemoryBalloon,
+        TRANSITIONAL_CONSOLE => DeviceType::Console,
+        TRANSITIONAL_SCSI_HOST => DeviceType::ScsiHost,
+        TRANSITIONAL_ENTROPY_SOURCE => DeviceType::EntropySource,
+        TRANSITIONAL_9P_TRANSPORT => DeviceType::_9P,
+        id if id >= PCI_DEVICE_ID_OFFSET => DeviceType::from(id - PCI_DEVICE_ID_OFFSET),
+        _ => DeviceType::Invalid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitional_device_ids() {
+        assert_eq!(device_type(0x1000), DeviceType::Network);
+        assert_eq!(device_type(0x1002), DeviceType::MemoryBalloon);
+        assert_eq!(device_type(0x1009), DeviceType::_9P);
+    }
+
+    #[test]
+    fn offset_device_ids() {
+        assert_eq!(device_type(0x1045), DeviceType::MemoryBalloon);
+        assert_eq!(device_type(0x1049), DeviceType::_9P);
+        assert_eq!(device_type(0x1058), DeviceType::Memory);
+        assert_eq!(device_type(0x1040), DeviceType::Invalid);
+        assert_eq!(device_type(0x1059), DeviceType::Invalid);
+    }
+}

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -255,7 +255,9 @@ impl PciRoot {
         // Get the size of the BAR.
         self.config_write_word(device_function, BAR0_OFFSET + 4 * bar_index, 0xffffffff);
         let size_mask = self.config_read_word(device_function, BAR0_OFFSET + 4 * bar_index);
-        let size = !(size_mask & 0xfffffff0) + 1;
+        // A wrapping add is necessary to correctly handle the case of unused BARs, which read back
+        // as 0, and should be treated as size 0.
+        let size = (!(size_mask & 0xfffffff0)).wrapping_add(1);
 
         // Restore the original value.
         self.config_write_word(device_function, BAR0_OFFSET + 4 * bar_index, bar_orig);

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -223,7 +223,7 @@ impl PciRoot {
     /// Gets an iterator over the capabilities of the given device function.
     pub fn capabilities(&self, device_function: DeviceFunction) -> CapabilityIterator {
         CapabilityIterator {
-            root: self.clone(),
+            root: self,
             device_function,
             next_capability_offset: self.capabilities_offset(device_function),
         }
@@ -401,13 +401,13 @@ impl TryFrom<u8> for MemoryBarType {
 
 /// Iterator over capabilities for a device.
 #[derive(Debug)]
-pub struct CapabilityIterator {
-    root: PciRoot,
+pub struct CapabilityIterator<'a> {
+    root: &'a PciRoot,
     device_function: DeviceFunction,
     next_capability_offset: Option<u8>,
 }
 
-impl Iterator for CapabilityIterator {
+impl<'a> Iterator for CapabilityIterator<'a> {
     type Item = CapabilityInfo;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -150,6 +150,8 @@ impl PciRoot {
     }
 
     fn cam_offset(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        assert!(device_function.valid());
+
         let bdf = (device_function.bus as u32) << 8
             | (device_function.device as u32) << 3
             | device_function.function as u32;
@@ -158,13 +160,11 @@ impl PciRoot {
             Cam::MmioCam => {
                 address = bdf << 8 | register_offset as u32;
                 // Ensure that address is within range.
-                // TODO: Return an error rather than panicking?
                 assert!(address < AARCH64_PCI_CFG_SIZE);
             }
             Cam::Ecam => {
                 address = bdf << 12 | register_offset as u32;
                 // Ensure that address is within range.
-                // TODO: Return an error rather than panicking?
                 assert!(address < AARCH64_PCIE_CFG_SIZE);
             }
         }
@@ -524,6 +524,14 @@ pub struct DeviceFunction {
     pub device: u8,
     /// The function number of the device, between 0 and 7.
     pub function: u8,
+}
+
+impl DeviceFunction {
+    /// Returns whether the device and function numbers are valid, i.e. the device is between 0 and
+    /// 31, and the function is between 0 and 7.
+    pub fn valid(&self) -> bool {
+        self.device < 32 && self.function < 8
+    }
 }
 
 impl Display for DeviceFunction {

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -322,6 +322,18 @@ pub enum BarInfo {
 }
 
 impl BarInfo {
+    /// Returns whether this BAR is a 64-bit memory region, and so takes two entries in the table in
+    /// configuration space.
+    pub fn takes_two_entries(&self) -> bool {
+        matches!(
+            self,
+            BarInfo::Memory {
+                address_type: MemoryBarType::Width64,
+                ..
+            }
+        )
+    }
+
     /// Returns the address and size of this BAR if it is a memory bar, or `None` if it is an IO
     /// BAR.
     pub fn memory_address_size(&self) -> Option<(u64, u32)> {

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -161,7 +161,11 @@ impl PciRoot {
     }
 
     /// Reads 4 bytes from configuration space using the appropriate CAM.
-    fn config_read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+    pub(crate) fn config_read_word(
+        &self,
+        device_function: DeviceFunction,
+        register_offset: u8,
+    ) -> u32 {
         let address = self.cam_offset(device_function, register_offset);
         // Safe because both the `mmio_base` and the address offset are properly aligned, and the
         // resulting pointer is within the MMIO range of the CAM.
@@ -172,7 +176,7 @@ impl PciRoot {
     }
 
     /// Writes 4 bytes to configuration space using the appropriate CAM.
-    fn config_write_word(
+    pub(crate) fn config_write_word(
         &mut self,
         device_function: DeviceFunction,
         register_offset: u8,
@@ -315,6 +319,18 @@ pub enum BarInfo {
         /// The size of the BAR in bytes.
         size: u32,
     },
+}
+
+impl BarInfo {
+    /// Returns the address and size of this BAR if it is a memory bar, or `None` if it is an IO
+    /// BAR.
+    pub fn memory_address_size(&self) -> Option<(u64, u32)> {
+        if let Self::Memory { address, size, .. } = self {
+            Some((*address, *size))
+        } else {
+            None
+        }
+    }
 }
 
 impl Display for BarInfo {

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -1,0 +1,193 @@
+//! Module for dealing with a PCI bus in general, without anything specific to VirtIO.
+
+use core::fmt::{self, Display, Formatter};
+
+const INVALID_READ: u32 = 0xffffffff;
+// PCI MMIO configuration region size.
+const AARCH64_PCI_CFG_SIZE: u32 = 0x1000000;
+// PCIe MMIO configuration region size.
+const AARCH64_PCIE_CFG_SIZE: u32 = 0x10000000;
+
+/// The maximum number of devices on a bus.
+const MAX_DEVICES: u8 = 32;
+/// The maximum number of functions on a device.
+const MAX_FUNCTIONS: u8 = 8;
+
+/// The root complex of a PCI bus.
+#[derive(Clone, Debug)]
+pub struct PciRoot {
+    mmio_base: *mut u32,
+    cam: Cam,
+}
+
+/// A PCI Configuration Access Mechanism.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Cam {
+    /// The PCI memory-mapped Configuration Access Mechanism.
+    ///
+    /// This provides access to 256 bytes of configuration space per device function.
+    MmioCam,
+    /// The PCIe memory-mapped Enhanced Configuration Access Mechanism.
+    ///
+    /// This provides access to 4 KiB of configuration space per device function.
+    Ecam,
+}
+
+impl PciRoot {
+    /// Wraps the PCI root complex with the given MMIO base address.
+    ///
+    /// Panics if the base address is not aligned to a 4-byte boundary.
+    ///
+    /// # Safety
+    ///
+    /// `mmio_base` must be a valid pointer to an appropriately-mapped MMIO region of at least
+    /// 16 MiB (if `cam == Cam::MmioCam`) or 256 MiB (if `cam == Cam::Ecam`). The pointer must be
+    /// valid for the entire lifetime of the program (i.e. `'static`), which implies that no Rust
+    /// references may be used to access any of the memory region at any point.
+    pub unsafe fn new(mmio_base: *mut u8, cam: Cam) -> Self {
+        assert!(mmio_base as usize & 0x3 == 0);
+        Self {
+            mmio_base: mmio_base as *mut u32,
+            cam,
+        }
+    }
+
+    fn cam_offset(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        let bdf = (device_function.bus as u32) << 8
+            | (device_function.device as u32) << 3
+            | device_function.function as u32;
+        let address;
+        match self.cam {
+            Cam::MmioCam => {
+                address = bdf << 8 | register_offset as u32;
+                // Ensure that address is within range.
+                // TODO: Return an error rather than panicking?
+                assert!(address < AARCH64_PCI_CFG_SIZE);
+            }
+            Cam::Ecam => {
+                address = bdf << 12 | register_offset as u32;
+                // Ensure that address is within range.
+                // TODO: Return an error rather than panicking?
+                assert!(address < AARCH64_PCIE_CFG_SIZE);
+            }
+        }
+        // Ensure that address is word-aligned.
+        assert!(address & 0x3 == 0);
+        address
+    }
+
+    /// Reads 4 bytes from configuration space using the appropriate CAM.
+    fn config_read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        let address = self.cam_offset(device_function, register_offset);
+        // Safe because both the `mmio_base` and the address offset are properly aligned, and the
+        // resulting pointer is within the MMIO range of the CAM.
+        unsafe {
+            // Right shift to convert from byte offset to word offset.
+            (self.mmio_base.add((address >> 2) as usize)).read_volatile()
+        }
+    }
+
+    /// Enumerates PCI devices on the given bus.
+    pub fn enumerate_bus(&self, bus: u8) -> BusDeviceIterator {
+        BusDeviceIterator {
+            root: self.clone(),
+            next: DeviceFunction {
+                bus,
+                device: 0,
+                function: 0,
+            },
+        }
+    }
+}
+
+/// An iterator which enumerates PCI devices and functions on a given bus.
+#[derive(Debug)]
+pub struct BusDeviceIterator {
+    root: PciRoot,
+    next: DeviceFunction,
+}
+
+impl Iterator for BusDeviceIterator {
+    type Item = (DeviceFunction, DeviceFunctionInfo);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next.device < MAX_DEVICES {
+            // Read the header for the current device and function.
+            let current = self.next;
+            let device_vendor = self.root.config_read_word(current, 0);
+
+            // Advance to the next device or function.
+            self.next.function += 1;
+            if self.next.function >= MAX_FUNCTIONS {
+                self.next.function = 0;
+                self.next.device += 1;
+            }
+
+            if device_vendor != INVALID_READ {
+                let class_revision = self.root.config_read_word(current, 8);
+                let device_id = (device_vendor >> 16) as u16;
+                let vendor_id = device_vendor as u16;
+                let class = (class_revision >> 24) as u8;
+                let subclass = (class_revision >> 16) as u8;
+                let prog_if = (class_revision >> 8) as u8;
+                let revision = class_revision as u8;
+                return Some((
+                    current,
+                    DeviceFunctionInfo {
+                        vendor_id,
+                        device_id,
+                        class,
+                        subclass,
+                        prog_if,
+                        revision,
+                    },
+                ));
+            }
+        }
+        None
+    }
+}
+
+/// An identifier for a PCI bus, device and function.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct DeviceFunction {
+    /// The PCI bus number, between 0 and 255.
+    pub bus: u8,
+    /// The device number on the bus, between 0 and 31.
+    pub device: u8,
+    /// The function number of the device, between 0 and 7.
+    pub function: u8,
+}
+
+impl Display for DeviceFunction {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:02x}:{:02x}.{}", self.bus, self.device, self.function)
+    }
+}
+
+/// Information about a PCI device function.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeviceFunctionInfo {
+    /// The PCI vendor ID.
+    pub vendor_id: u16,
+    /// The PCI device ID.
+    pub device_id: u16,
+    /// The PCI class.
+    pub class: u8,
+    /// The PCI subclass.
+    pub subclass: u8,
+    /// The PCI programming interface byte.
+    pub prog_if: u8,
+    /// The PCI revision ID.
+    pub revision: u8,
+}
+
+impl Display for DeviceFunctionInfo {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:04x} (class {:02x}.{:02x}, rev {:02x})",
+            self.vendor_id, self.device_id, self.class, self.subclass, self.revision
+        )
+    }
+}


### PR DESCRIPTION
This is a fairly big PR, but I've tried to make the individual commits fairly logical and self-contained. Let me know if you'd prefer me to split it into several PRs.

Most of the code is in two new modules:
 * `transport::pci::bus` contains the generic PCI part of it, mostly around accessing PCI configuration space via one of two possible CAMs.
 * `transport::pci` contains the VirtIO-specific parts, primarily the `PciTransport` struct which implements the `Transport` trait.

I also fixed the device implementations to avoid non-volatile access to their VirtIO config regions, which was happening through the `Debug` implementations.

You can try the new implementation on aarch64 with `cd examples/aarch64/ && make qemu-pci`.