### PR TITLE
Check size of config space

### DIFF
--- a/src/blk.rs
+++ b/src/blk.rs
@@ -31,7 +31,9 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         let config = transport.config_space().cast::<BlkConfig>();
         info!("config: {:?}", config);
         // Safe because config is a valid pointer to the device configuration space.
-        let capacity = unsafe { volread!(config, capacity) };
+        let capacity = unsafe {
+            volread!(config, capacity_low) as u64 | (volread!(config, capacity_high) as u64) << 32
+        };
         info!("found a block device of size {}KB", capacity / 2);
 
         let queue = VirtQueue::new(&mut transport, 0, 16)?;
@@ -192,7 +194,8 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
 #[repr(C)]
 struct BlkConfig {
     /// Number of 512 Bytes sectors
-    capacity: Volatile<u64>,
+    capacity_low: Volatile<u32>,
+    capacity_high: Volatile<u32>,
     size_max: Volatile<u32>,
     seg_max: Volatile<u32>,
     cylinders: Volatile<u16>,

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -28,7 +28,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         });
 
         // read configuration space
-        let config = transport.config_space().cast::<BlkConfig>();
+        let config = transport.config_space::<BlkConfig>();
         info!("config: {:?}", config);
         // Safe because config is a valid pointer to the device configuration space.
         let capacity = unsafe {

--- a/src/blk.rs
+++ b/src/blk.rs
@@ -28,7 +28,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         });
 
         // read configuration space
-        let config = transport.config_space::<BlkConfig>();
+        let config = transport.config_space::<BlkConfig>()?;
         info!("config: {:?}", config);
         // Safe because config is a valid pointer to the device configuration space.
         let capacity = unsafe {

--- a/src/console.rs
+++ b/src/console.rs
@@ -31,7 +31,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
             let supported_features = Features::empty();
             (features & supported_features).bits()
         });
-        let config_space = transport.config_space().cast::<Config>();
+        let config_space = transport.config_space::<Config>();
         unsafe {
             let columns = volread!(config_space, cols);
             let rows = volread!(config_space, rows);
@@ -171,10 +171,10 @@ mod tests {
             device_type: DeviceType::Console,
             max_queue_size: 2,
             device_features: 0,
-            config_space: NonNull::from(&mut config_space).cast(),
+            config_space: NonNull::from(&mut config_space),
             state: state.clone(),
         };
-        let mut console = VirtIOConsole::<FakeHal, FakeTransport>::new(transport).unwrap();
+        let mut console = VirtIOConsole::<FakeHal, FakeTransport<Config>>::new(transport).unwrap();
 
         // Nothing is available to receive.
         assert_eq!(console.recv(false).unwrap(), None);

--- a/src/console.rs
+++ b/src/console.rs
@@ -31,7 +31,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
             let supported_features = Features::empty();
             (features & supported_features).bits()
         });
-        let config_space = transport.config_space::<Config>();
+        let config_space = transport.config_space::<Config>()?;
         unsafe {
             let columns = volread!(config_space, cols);
             let rows = volread!(config_space, rows);

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -43,7 +43,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         });
 
         // read configuration space
-        let config_space = transport.config_space().cast::<Config>();
+        let config_space = transport.config_space::<Config>();
         unsafe {
             let events_read = volread!(config_space, events_read);
             let num_scanouts = volread!(config_space, num_scanouts);

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -43,7 +43,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         });
 
         // read configuration space
-        let config_space = transport.config_space::<Config>();
+        let config_space = transport.config_space::<Config>()?;
         unsafe {
             let events_read = volread!(config_space, events_read);
             let num_scanouts = volread!(config_space, num_scanouts);

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,7 +75,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
         subsel: u8,
         out: &mut [u8],
     ) -> u8 {
-        let config = self.transport.config_space().cast::<Config>();
+        let config = self.transport.config_space::<Config>();
         let size;
         let data;
         // Safe because config points to a valid MMIO region for the config space.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ pub enum Error {
     DmaError,
     /// I/O Error
     IoError,
+    /// The config space advertised by the device is smaller than the driver expected.
+    ConfigSpaceTooSmall,
+    /// The device doesn't have any config space, but the driver expects some.
+    ConfigSpaceMissing,
 }
 
 /// Align `size` up to a page.

--- a/src/net.rs
+++ b/src/net.rs
@@ -31,7 +31,7 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
             (features & supported_features).bits()
         });
         // read configuration space
-        let config = transport.config_space::<Config>();
+        let config = transport.config_space::<Config>()?;
         let mac;
         // Safe because config points to a valid MMIO region for the config space.
         unsafe {

--- a/src/net.rs
+++ b/src/net.rs
@@ -31,7 +31,7 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
             (features & supported_features).bits()
         });
         // read configuration space
-        let config = transport.config_space().cast::<Config>();
+        let config = transport.config_space::<Config>();
         let mac;
         // Safe because config points to a valid MMIO region for the config space.
         unsafe {

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -13,7 +13,7 @@ pub struct FakeTransport {
     pub device_type: DeviceType,
     pub max_queue_size: u32,
     pub device_features: u64,
-    pub config_space: NonNull<u64>,
+    pub config_space: NonNull<u32>,
     pub state: Arc<Mutex<State>>,
 }
 
@@ -74,7 +74,7 @@ impl Transport for FakeTransport {
         pending
     }
 
-    fn config_space(&self) -> NonNull<u64> {
+    fn config_space(&self) -> NonNull<u32> {
         self.config_space
     }
 }

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -1,7 +1,7 @@
 use super::{DeviceStatus, Transport};
 use crate::{
     queue::{fake_write_to_queue, Descriptor},
-    DeviceType, PhysAddr,
+    DeviceType, PhysAddr, Result,
 };
 use alloc::{sync::Arc, vec::Vec};
 use core::{any::TypeId, ptr::NonNull};
@@ -74,9 +74,9 @@ impl<C> Transport for FakeTransport<C> {
         pending
     }
 
-    fn config_space<T: 'static>(&self) -> NonNull<T> {
+    fn config_space<T: 'static>(&self) -> Result<NonNull<T>> {
         if TypeId::of::<T>() == TypeId::of::<C>() {
-            self.config_space.cast()
+            Ok(self.config_space.cast())
         } else {
             panic!("Unexpected config space type.");
         }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -3,7 +3,7 @@ use crate::{
     align_up,
     queue::Descriptor,
     volatile::{volread, volwrite, ReadOnly, Volatile, WriteOnly},
-    PhysAddr, PAGE_SIZE,
+    Error, PhysAddr, PAGE_SIZE,
 };
 use core::{
     convert::{TryFrom, TryInto},
@@ -442,7 +442,7 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn config_space<T>(&self) -> NonNull<T> {
-        NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap()
+    fn config_space<T>(&self) -> Result<NonNull<T>, Error> {
+        Ok(NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap())
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -442,7 +442,7 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn config_space(&self) -> NonNull<u64> {
+    fn config_space(&self) -> NonNull<u32> {
         NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap()
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -442,7 +442,7 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn config_space(&self) -> NonNull<u32> {
+    fn config_space<T>(&self) -> NonNull<T> {
         NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap()
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -8,7 +8,7 @@ use crate::{
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Display, Formatter},
-    mem::size_of,
+    mem::{align_of, size_of},
     ptr::NonNull,
 };
 
@@ -443,6 +443,13 @@ impl Transport for MmioTransport {
     }
 
     fn config_space<T>(&self) -> Result<NonNull<T>, Error> {
+        if align_of::<T>() > 4 {
+            // Panic as this should only happen if the driver is written incorrectly.
+            panic!(
+                "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+                align_of::<T>()
+            );
+        }
         Ok(NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap())
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -74,7 +74,7 @@ pub trait Transport {
     }
 
     /// Gets the pointer to the config space.
-    fn config_space(&self) -> NonNull<u32>;
+    fn config_space<T: 'static>(&self) -> NonNull<T>;
 }
 
 bitflags! {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -3,7 +3,7 @@ pub mod fake;
 pub mod mmio;
 pub mod pci;
 
-use crate::{PhysAddr, PAGE_SIZE};
+use crate::{PhysAddr, Result, PAGE_SIZE};
 use bitflags::bitflags;
 use core::ptr::NonNull;
 
@@ -74,7 +74,7 @@ pub trait Transport {
     }
 
     /// Gets the pointer to the config space.
-    fn config_space<T: 'static>(&self) -> NonNull<T>;
+    fn config_space<T: 'static>(&self) -> Result<NonNull<T>>;
 }
 
 bitflags! {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -74,7 +74,7 @@ pub trait Transport {
     }
 
     /// Gets the pointer to the config space.
-    fn config_space(&self) -> NonNull<u64>;
+    fn config_space(&self) -> NonNull<u32>;
 }
 
 bitflags! {

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -91,7 +91,7 @@ pub struct PciTransport {
     /// The ISR status register within some BAR.
     isr_status: NonNull<Volatile<u8>>,
     /// The VirtIO device-specific configuration within some BAR.
-    config_space: Option<NonNull<[u64]>>,
+    config_space: Option<NonNull<[u32]>>,
 }
 
 impl PciTransport {
@@ -300,7 +300,7 @@ impl Transport for PciTransport {
         isr_status & 0x3 != 0
     }
 
-    fn config_space(&self) -> NonNull<u64> {
+    fn config_space(&self) -> NonNull<u32> {
         // TODO: Check config_space_size
         // TODO: Use NonNull::as_non_null_ptr once it is stable.
         NonNull::new(

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -305,6 +305,12 @@ impl Transport for PciTransport {
         if let Some(config_space) = self.config_space {
             if size_of::<T>() > config_space.len() * size_of::<u32>() {
                 Err(Error::ConfigSpaceTooSmall)
+            } else if align_of::<T>() > 4 {
+                // Panic as this should only happen if the driver is written incorrectly.
+                panic!(
+                    "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+                    align_of::<T>()
+                );
             } else {
                 // TODO: Use NonNull::as_non_null_ptr once it is stable.
                 let config_space_ptr = NonNull::new(config_space.as_ptr() as *mut u32).unwrap();


### PR DESCRIPTION
At least in the case of the PCI transport, the device says how big its configuration space is. We should check that it is at least as big as we expect, and return an error if not, to avoid possible out of bounds accesses.

This PR also reduces the alignment requirement for device config space from 8 bytes to 4 bytes, to match what the VirtIO specification allows.