### PR TITLE
Fix soundness issues with VirtQueue

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -60,7 +60,8 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
     }
 
     fn poll_retrieve(&mut self) -> Result<()> {
-        self.receiveq.add(&[], &[self.queue_buf_rx])?;
+        // Safe because the buffer lasts at least as long as the queue.
+        unsafe { self.receiveq.add(&[], &[self.queue_buf_rx])? };
         Ok(())
     }
 
@@ -99,12 +100,14 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
     /// Put a char onto the device.
     pub fn send(&mut self, chr: u8) -> Result<()> {
         let buf: [u8; 1] = [chr];
-        self.transmitq.add(&[&buf], &[])?;
+        // Safe because the buffer is valid until we pop_used below.
+        let token = unsafe { self.transmitq.add(&[&buf], &[]) }?;
         self.transport.notify(QUEUE_TRANSMITQ_PORT_0);
         while !self.transmitq.can_pop() {
             spin_loop();
         }
-        self.transmitq.pop_used()?;
+        let (popped_token, _) = self.transmitq.pop_used()?;
+        assert_eq!(popped_token, token);
         Ok(())
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -3,7 +3,7 @@ use crate::queue::VirtQueue;
 use crate::transport::Transport;
 use crate::volatile::{volread, ReadOnly, Volatile, WriteOnly};
 use bitflags::*;
-use core::{fmt, hint::spin_loop};
+use core::fmt;
 use log::*;
 
 /// A virtio based graphics adapter.
@@ -169,16 +169,11 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         unsafe {
             (self.queue_buf_send.as_mut_ptr() as *mut Req).write(req);
         }
-        let token = unsafe {
-            self.control_queue
-                .add(&[self.queue_buf_send], &[self.queue_buf_recv])?
-        };
-        self.transport.notify(QUEUE_TRANSMIT);
-        while !self.control_queue.can_pop() {
-            spin_loop();
-        }
-        let (popped_token, _) = self.control_queue.pop_used()?;
-        assert_eq!(popped_token, token);
+        self.control_queue.add_notify_wait_pop(
+            &[self.queue_buf_send],
+            &[self.queue_buf_recv],
+            &mut self.transport,
+        )?;
         Ok(unsafe { (self.queue_buf_recv.as_ptr() as *const Rsp).read() })
     }
 
@@ -187,13 +182,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         unsafe {
             (self.queue_buf_send.as_mut_ptr() as *mut Req).write(req);
         }
-        let token = unsafe { self.cursor_queue.add(&[self.queue_buf_send], &[])? };
-        self.transport.notify(QUEUE_CURSOR);
-        while !self.cursor_queue.can_pop() {
-            spin_loop();
-        }
-        let (popped_token, _) = self.cursor_queue.pop_used()?;
-        assert_eq!(popped_token, token);
+        self.cursor_queue
+            .add_notify_wait_pop(&[self.queue_buf_send], &[], &mut self.transport)?;
         Ok(())
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -77,13 +77,15 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
     pub fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
         let mut header = MaybeUninit::<Header>::uninit();
         let header_buf = unsafe { (*header.as_mut_ptr()).as_buf_mut() };
-        self.recv_queue.add(&[], &[header_buf, buf])?;
+        // Safe because the buffers are valid at least until we pop_used below.
+        let token = unsafe { self.recv_queue.add(&[], &[header_buf, buf])? };
         self.transport.notify(QUEUE_RECEIVE);
         while !self.recv_queue.can_pop() {
             spin_loop();
         }
 
-        let (_, len) = self.recv_queue.pop_used()?;
+        let (popped_token, len) = self.recv_queue.pop_used()?;
+        assert_eq!(popped_token, token);
         // let header = unsafe { header.assume_init() };
         Ok(len as usize - size_of::<Header>())
     }
@@ -91,12 +93,14 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
     /// Send a packet.
     pub fn send(&mut self, buf: &[u8]) -> Result {
         let header = unsafe { MaybeUninit::<Header>::zeroed().assume_init() };
-        self.send_queue.add(&[header.as_buf(), buf], &[])?;
+        // Safe because the buffers are valid at least until we pop_used below.
+        let token = unsafe { self.send_queue.add(&[header.as_buf(), buf], &[])? };
         self.transport.notify(QUEUE_TRANSMIT);
         while !self.send_queue.can_pop() {
             spin_loop();
         }
-        self.send_queue.pop_used()?;
+        let (popped_token, _) = self.send_queue.pop_used()?;
+        assert_eq!(popped_token, token);
         Ok(())
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -4,7 +4,6 @@ use super::*;
 use crate::transport::Transport;
 use crate::volatile::{volread, ReadOnly, Volatile};
 use bitflags::*;
-use core::hint::spin_loop;
 use log::*;
 
 /// The virtio network device is a virtual ethernet card.
@@ -77,15 +76,9 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
     pub fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
         let mut header = MaybeUninit::<Header>::uninit();
         let header_buf = unsafe { (*header.as_mut_ptr()).as_buf_mut() };
-        // Safe because the buffers are valid at least until we pop_used below.
-        let token = unsafe { self.recv_queue.add(&[], &[header_buf, buf])? };
-        self.transport.notify(QUEUE_RECEIVE);
-        while !self.recv_queue.can_pop() {
-            spin_loop();
-        }
-
-        let (popped_token, len) = self.recv_queue.pop_used()?;
-        assert_eq!(popped_token, token);
+        let len =
+            self.recv_queue
+                .add_notify_wait_pop(&[], &[header_buf, buf], &mut self.transport)?;
         // let header = unsafe { header.assume_init() };
         Ok(len as usize - size_of::<Header>())
     }
@@ -93,14 +86,8 @@ impl<H: Hal, T: Transport> VirtIONet<H, T> {
     /// Send a packet.
     pub fn send(&mut self, buf: &[u8]) -> Result {
         let header = unsafe { MaybeUninit::<Header>::zeroed().assume_init() };
-        // Safe because the buffers are valid at least until we pop_used below.
-        let token = unsafe { self.send_queue.add(&[header.as_buf(), buf], &[])? };
-        self.transport.notify(QUEUE_TRANSMIT);
-        while !self.send_queue.can_pop() {
-            spin_loop();
-        }
-        let (popped_token, _) = self.send_queue.pop_used()?;
-        assert_eq!(popped_token, token);
+        self.send_queue
+            .add_notify_wait_pop(&[header.as_buf(), buf], &[], &mut self.transport)?;
         Ok(())
     }
 }


### PR DESCRIPTION
`Queue::add` must be marked as unsafe, because the caller must ensure that the input and output buffers remain valid until device has finished using them. I've added a helper method `Queue::add_notify_wait_pop` to handle the blocking case safely. This doesn't return until the matching token has been popped from the queue.