### PR TITLE
Expose PAGE_SIZE constant.

### DIFF
--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -1,9 +1,7 @@
 use core::sync::atomic::*;
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{Hal, PhysAddr, VirtAddr};
-
-const PAGE_SIZE: usize = 0x1000;
+use virtio_drivers::{Hal, PhysAddr, VirtAddr, PAGE_SIZE};
 
 extern "C" {
     static dma_region: u8;

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::*;
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{Hal, PhysAddr, VirtAddr};
+use virtio_drivers::{Hal, PhysAddr, VirtAddr, PAGE_SIZE};
 
 extern "C" {
     fn end();
@@ -15,7 +15,7 @@ pub struct HalImpl;
 
 impl Hal for HalImpl {
     fn dma_alloc(pages: usize) -> PhysAddr {
-        let paddr = DMA_PADDR.fetch_add(0x1000 * pages, Ordering::SeqCst);
+        let paddr = DMA_PADDR.fetch_add(PAGE_SIZE * pages, Ordering::SeqCst);
         trace!("alloc DMA: paddr={:#x}, pages={}", paddr, pages);
         paddr
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use core::mem::size_of;
 use hal::*;
 
 /// The page size in bytes supported by the library (4 KiB).
-const PAGE_SIZE: usize = 0x1000;
+pub const PAGE_SIZE: usize = 0x1000;
 
 /// The type returned by driver methods.
 pub type Result<T = ()> = core::result::Result<T, Error>;


### PR DESCRIPTION
HAL implementations need to know it to know how much to allocate.