### PR TITLE
Fix some clippy warnings.

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -15,7 +15,7 @@ pub struct VirtIOConsole<'a, H: Hal, T: Transport> {
     transport: T,
     receiveq: VirtQueue<H>,
     transmitq: VirtQueue<H>,
-    queue_buf_dma: DMA<H>,
+    queue_buf_dma: Dma<H>,
     queue_buf_rx: &'a mut [u8],
     cursor: usize,
     pending_len: usize,
@@ -42,7 +42,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
         }
         let receiveq = VirtQueue::new(&mut transport, QUEUE_RECEIVEQ_PORT_0, QUEUE_SIZE)?;
         let transmitq = VirtQueue::new(&mut transport, QUEUE_TRANSMITQ_PORT_0, QUEUE_SIZE)?;
-        let queue_buf_dma = DMA::new(1)?;
+        let queue_buf_dma = Dma::new(1)?;
         let queue_buf_rx = unsafe { &mut queue_buf_dma.as_buf()[0..] };
         transport.finish_init();
         let mut console = VirtIOConsole {
@@ -72,7 +72,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
         }
         let mut flag = false;
         while let Ok((_token, len)) = self.receiveq.pop_used() {
-            assert_eq!(flag, false);
+            assert!(!flag);
             flag = true;
             assert_ne!(len, 0);
             self.cursor = 0;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -17,15 +17,15 @@ pub struct VirtIOGpu<'a, H: Hal, T: Transport> {
     transport: T,
     rect: Option<Rect>,
     /// DMA area of frame buffer.
-    frame_buffer_dma: Option<DMA<H>>,
+    frame_buffer_dma: Option<Dma<H>>,
     /// DMA area of cursor image buffer.
-    cursor_buffer_dma: Option<DMA<H>>,
+    cursor_buffer_dma: Option<Dma<H>>,
     /// Queue for sending control commands.
     control_queue: VirtQueue<H>,
     /// Queue for sending cursor commands.
     cursor_queue: VirtQueue<H>,
     /// Queue buffer DMA
-    queue_buf_dma: DMA<H>,
+    queue_buf_dma: Dma<H>,
     /// Send buffer for queue.
     queue_buf_send: &'a mut [u8],
     /// Recv buffer for queue.
@@ -56,7 +56,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         let control_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT, 2)?;
         let cursor_queue = VirtQueue::new(&mut transport, QUEUE_CURSOR, 2)?;
 
-        let queue_buf_dma = DMA::new(2)?;
+        let queue_buf_dma = Dma::new(2)?;
         let queue_buf_send = unsafe { &mut queue_buf_dma.as_buf()[..PAGE_SIZE] };
         let queue_buf_recv = unsafe { &mut queue_buf_dma.as_buf()[PAGE_SIZE..] };
 
@@ -102,7 +102,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
 
         // alloc continuous pages for the frame buffer
         let size = display_info.rect.width * display_info.rect.height * 4;
-        let frame_buffer_dma = DMA::new(pages(size as usize))?;
+        let frame_buffer_dma = Dma::new(pages(size as usize))?;
 
         // resource_attach_backing
         self.resource_attach_backing(RESOURCE_ID_FB, frame_buffer_dma.paddr() as u64, size)?;
@@ -138,7 +138,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<'_, H, T> {
         if cursor_image.len() != size as usize {
             return Err(Error::InvalidParam);
         }
-        let cursor_buffer_dma = DMA::new(pages(size as usize))?;
+        let cursor_buffer_dma = Dma::new(pages(size as usize))?;
         let buf = unsafe { cursor_buffer_dma.as_buf() };
         buf.copy_from_slice(cursor_image);
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -210,11 +210,11 @@ bitflags! {
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum GsoType {
-    NONE = 0,
-    TCPV4 = 1,
-    UDP = 3,
-    TCPV6 = 4,
-    ECN = 0x80,
+    None = 0,
+    TcpV4 = 1,
+    Udp = 3,
+    TcpV6 = 4,
+    Ecn = 0x80,
 }
 
 const QUEUE_RECEIVE: u16 = 0;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -15,7 +15,7 @@ use bitflags::*;
 #[derive(Debug)]
 pub struct VirtQueue<H: Hal> {
     /// DMA guard
-    dma: DMA<H>,
+    dma: Dma<H>,
     /// Descriptor table
     desc: NonNull<[Descriptor]>,
     /// Available ring
@@ -49,7 +49,7 @@ impl<H: Hal> VirtQueue<H> {
         }
         let layout = VirtQueueLayout::new(size);
         // Allocate contiguous pages.
-        let dma = DMA::new(layout.size / PAGE_SIZE)?;
+        let dma = Dma::new(layout.size / PAGE_SIZE)?;
 
         transport.queue_set(
             idx,


### PR DESCRIPTION
Clippy doesn't like all-caps type or enum variant names, or unnecessary casts.