### PR TITLE
Improve VirtIOConsole

### DIFF
--- a/examples/aarch64/Makefile
+++ b/examples/aarch64/Makefile
@@ -42,25 +42,30 @@ qemu: $(kernel_bin) $(img)
 	  $(QEMU_ARGS) \
 		-machine virt \
 		-cpu max \
-		-serial mon:stdio \
+		-serial chardev:char0 \
 		-kernel $(kernel_bin) \
 		-global virtio-mmio.force-legacy=false \
 		-nic none \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
-		-device virtio-gpu-device
+		-device virtio-gpu-device \
+		-device virtio-serial,id=virtio-serial0 \
+		-chardev stdio,id=char0,mux=on \
+		-device virtconsole,chardev=char0
 
 qemu-pci: $(kernel_bin) $(img)
 	qemu-system-aarch64 \
 		-machine virt \
 		-cpu max \
-		-serial mon:stdio \
+		-serial chardev:char0 \
 		-kernel $(kernel_bin) \
 		-nic none \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-pci,drive=x0 \
 		-device virtio-gpu-pci \
-		-device virtio-serial,id=virtio-serial0
+		-device virtio-serial,id=virtio-serial0 \
+		-chardev stdio,id=char0,mux=on \
+		-device virtconsole,chardev=char0
 
 $(img):
 	dd if=/dev/zero of=$@ bs=512 count=32


### PR DESCRIPTION
* Added a method to get information such as the number of rows and columns.
* Keep track of the token of the outstanding receive request, and ensure there is never more than one.
* Check whether the request has completed at the start of `recv` as well as in `ack_interrupt`, in case the client is not using interrupts.
* Added some more documentation.
* Added a test in the aarch64 example.