### PR TITLE
Rename Error::BufferTooSmall to QueueFull and improve documentation.

### DIFF
--- a/src/blk.rs
+++ b/src/blk.rs
@@ -130,7 +130,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     ///
     /// It will submit request to the VirtIO block device and return a token identifying
     /// the position of the first Descriptor in the chain. If there are not enough
-    /// Descriptors to allocate, then it returns [Error::BufferTooSmall].
+    /// Descriptors to allocate, then it returns [`Error::QueueFull`].
     ///
     /// The caller can then call `pop_used` to check whether the device has finished handling the
     /// request. Once it has, the caller can then read the response and dispose of the buffers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ pub type Result<T = ()> = core::result::Result<T, Error>;
 /// The error type of VirtIO drivers.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
-    /// The buffer is too small.
-    BufferTooSmall,
+    /// There are not enough descriptors available in the virtqueue, try again later.
+    QueueFull,
     /// The device is not ready.
     NotReady,
     /// The queue is already in use.

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -85,7 +85,6 @@ pub struct PciTransport {
     device_function: DeviceFunction,
     /// The common configuration structure within some BAR.
     common_cfg: NonNull<CommonCfg>,
-    // TODO: Use a raw slice, once they are supported by our MSRV.
     /// The start of the queue notification region within some BAR.
     notify_region: NonNull<[WriteOnly<u16>]>,
     notify_off_multiplier: u32,


### PR DESCRIPTION
This is a more accurate description of the issue.