### PR TITLE
Writing 0 to queue_enable for PCI transport isn't allowed.

### DIFF
--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -290,7 +290,6 @@ impl Transport for PciTransport {
         // Safe because the common config pointer is valid and we checked in get_bar_region that it
         // was aligned.
         unsafe {
-            volwrite!(self.common_cfg, queue_enable, 0);
             volwrite!(self.common_cfg, queue_select, queue);
             volwrite!(self.common_cfg, queue_size, 0);
             volwrite!(self.common_cfg, queue_desc, 0);


### PR DESCRIPTION
(Writing 0 to QueueReady with MMIO transport is, however.)