### PR TITLE
Improve error reporting of VirtIOBlk

### DIFF
--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -209,7 +209,10 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     ) -> Result<()> {
         self.queue
             .pop_used(token, &[req.as_bytes()], &[buf, resp.as_bytes_mut()])?;
-        Ok(())
+        match resp.status {
+            RespStatus::OK => Ok(()),
+            _ => Err(Error::IoError),
+        }
     }
 
     /// Writes the contents of the given buffer to a block.
@@ -291,7 +294,10 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     ) -> Result<()> {
         self.queue
             .pop_used(token, &[req.as_bytes(), buf], &[resp.as_bytes_mut()])?;
-        Ok(())
+        match resp.status {
+            RespStatus::OK => Ok(()),
+            _ => Err(Error::IoError),
+        }
     }
 
     /// Fetches the token of the next completed request from the used ring and returns it, without

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ pub enum Error {
     DmaError,
     /// I/O Error
     IoError,
+    /// The request was not supported by the device.
+    Unsupported,
     /// The config space advertised by the device is smaller than the driver expected.
     ConfigSpaceTooSmall,
     /// The device doesn't have any config space, but the driver expects some.


### PR DESCRIPTION
* Convert different response statuses from device to different `Error` variants rather than converting them all to `Error::IoError`.
* Return the same errors from `complete_read_block` and `complete_write_block` as from the blocking versions, for consistency.