### PR TITLE
Support available buffer notification suppression, and send notifications for console and input

### DIFF
--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -188,7 +188,9 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         let token = self
             .queue
             .add(&[req.as_bytes()], &[buf, resp.as_bytes_mut()])?;
-        self.transport.notify(QUEUE);
+        if self.queue.should_notify() {
+            self.transport.notify(QUEUE);
+        }
         Ok(token)
     }
 
@@ -267,7 +269,9 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         let token = self
             .queue
             .add(&[req.as_bytes(), buf], &[resp.as_bytes_mut()])?;
-        self.transport.notify(QUEUE);
+        if self.queue.should_notify() {
+            self.transport.notify(QUEUE);
+        }
         Ok(token)
     }
 

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -119,6 +119,9 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
             // Safe because the buffer lasts at least as long as the queue, and there are no other
             // outstanding requests using the buffer.
             self.receive_token = Some(unsafe { self.receiveq.add(&[], &[self.queue_buf_rx]) }?);
+            if self.receiveq.should_notify() {
+                self.transport.notify(QUEUE_RECEIVEQ_PORT_0);
+            }
         }
         Ok(())
     }

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -45,6 +45,9 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             let token = unsafe { event_queue.add(&[], &[event.as_bytes_mut()])? };
             assert_eq!(token, i as u16);
         }
+        if event_queue.should_notify() {
+            transport.notify(QUEUE_EVENT);
+        }
 
         transport.finish_init();
 
@@ -76,6 +79,9 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
                 // the list of free descriptors in the queue, so `add` reuses the descriptor which
                 // was just freed by `pop_used`.
                 assert_eq!(new_token, token);
+                if self.event_queue.should_notify() {
+                    self.transport.notify(QUEUE_EVENT);
+                }
                 return Some(*event);
             }
         }


### PR DESCRIPTION
The `VirtIOConsole` and `VirtIOInput` drivers weren't sending available buffer notifications to the device like they should, so I've fixed that. I've also implemented support for the device to suppress available buffer notifications using the flags on the used ring.