### PR TITLE
Reset device when the transport is dropped.

### DIFF
--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -490,3 +490,10 @@ impl Transport for MmioTransport {
         Ok(NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap())
     }
 }
+
+impl Drop for MmioTransport {
+    fn drop(&mut self) {
+        // Reset the device when the transport is dropped.
+        self.set_status(DeviceStatus::empty())
+    }
+}

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -338,6 +338,13 @@ impl Transport for PciTransport {
     }
 }
 
+impl Drop for PciTransport {
+    fn drop(&mut self) {
+        // Reset the device when the transport is dropped.
+        self.set_status(DeviceStatus::empty())
+    }
+}
+
 /// `virtio_pci_common_cfg`, see 4.1.4.3 "Common configuration structure layout".
 #[repr(C)]
 struct CommonCfg {


### PR DESCRIPTION
Otherwise the driver will fail to initialise it next time, as the queues will already be set.