### PR TITLE
Allow HAL to validate MMIO ranges

### DIFF
--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, VirtAddr, PAGE_SIZE};
+use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     static dma_region: u8;
@@ -46,6 +46,6 @@ impl Hal for HalImpl {
     }
 }
 
-fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+fn virt_to_phys(vaddr: usize) -> PhysAddr {
     vaddr
 }

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -18,13 +18,14 @@ lazy_static! {
 pub struct HalImpl;
 
 impl Hal for HalImpl {
-    fn dma_alloc(pages: usize, _direction: BufferDirection) -> PhysAddr {
+    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (PhysAddr, NonNull<u8>) {
         let paddr = DMA_PADDR.fetch_add(PAGE_SIZE * pages, Ordering::SeqCst);
         trace!("alloc DMA: paddr={:#x}, pages={}", paddr, pages);
-        paddr
+        let vaddr = NonNull::new(paddr as _).unwrap();
+        (paddr, vaddr)
     }
 
-    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
+    fn dma_dealloc(paddr: PhysAddr, _vaddr: NonNull<u8>, pages: usize) -> i32 {
         trace!("dealloc DMA: paddr={:#x}, pages={}", paddr, pages);
         0
     }

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -30,7 +30,7 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
         paddr
     }
 

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -30,8 +30,8 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
-        paddr
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(paddr as _).unwrap()
     }
 
     fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -30,7 +30,7 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+    fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
         NonNull::new(paddr as _).unwrap()
     }
 

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -29,7 +29,7 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
         paddr
     }
 

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -29,8 +29,8 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
-        paddr
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(paddr as _).unwrap()
     }
 
     fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -29,7 +29,7 @@ impl Hal for HalImpl {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+    fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
         NonNull::new(paddr as _).unwrap()
     }
 

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -17,13 +17,14 @@ lazy_static! {
 pub struct HalImpl;
 
 impl Hal for HalImpl {
-    fn dma_alloc(pages: usize, _direction: BufferDirection) -> PhysAddr {
+    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (PhysAddr, NonNull<u8>) {
         let paddr = DMA_PADDR.fetch_add(PAGE_SIZE * pages, Ordering::SeqCst);
         trace!("alloc DMA: paddr={:#x}, pages={}", paddr, pages);
-        paddr
+        let vaddr = NonNull::new(paddr as _).unwrap();
+        (paddr, vaddr)
     }
 
-    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
+    fn dma_dealloc(paddr: PhysAddr, _vaddr: NonNull<u8>, pages: usize) -> i32 {
         trace!("dealloc DMA: paddr={:#x}, pages={}", paddr, pages);
         0
     }

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, VirtAddr, PAGE_SIZE};
+use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     fn end();
@@ -45,6 +45,6 @@ impl Hal for HalImpl {
     }
 }
 
-fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+fn virt_to_phys(vaddr: usize) -> PhysAddr {
     vaddr
 }

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -73,8 +73,9 @@ pub trait Hal {
     /// Converts a physical address used for MMIO to a virtual address which the driver can access.
     ///
     /// This is only used for MMIO addresses within BARs read from the device, for the PCI
-    /// transport.
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr;
+    /// transport. It may check that the address range up to the given size is within the region
+    /// expected for MMIO.
+    fn phys_to_virt(paddr: PhysAddr, size: usize) -> VirtAddr;
     /// Shares the given memory range with the device, and returns the physical address that the
     /// device can use to access it.
     ///

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -14,6 +14,7 @@ pub type PhysAddr = usize;
 #[derive(Debug)]
 pub struct Dma<H: Hal> {
     paddr: usize,
+    vaddr: NonNull<u8>,
     pages: usize,
     _phantom: PhantomData<H>,
 }
@@ -22,12 +23,13 @@ impl<H: Hal> Dma<H> {
     /// Allocates the given number of pages of physically contiguous memory to be used for DMA in
     /// the given direction.
     pub fn new(pages: usize, direction: BufferDirection) -> Result<Self> {
-        let paddr = H::dma_alloc(pages, direction);
+        let (paddr, vaddr) = H::dma_alloc(pages, direction);
         if paddr == 0 {
             return Err(Error::DmaError);
         }
         Ok(Self {
             paddr,
+            vaddr,
             pages,
             _phantom: PhantomData::default(),
         })
@@ -41,7 +43,7 @@ impl<H: Hal> Dma<H> {
     /// Returns a pointer to the given offset within the DMA region.
     pub fn vaddr(&self, offset: usize) -> NonNull<u8> {
         assert!(offset < self.pages * PAGE_SIZE);
-        NonNull::new((H::phys_to_virt(self.paddr) + offset) as _).unwrap()
+        NonNull::new((self.vaddr.as_ptr() as usize + offset) as _).unwrap()
     }
 
     /// Returns a pointer to the entire DMA region as a slice.
@@ -54,22 +56,24 @@ impl<H: Hal> Dma<H> {
 
 impl<H: Hal> Drop for Dma<H> {
     fn drop(&mut self) {
-        let err = H::dma_dealloc(self.paddr, self.pages);
+        let err = H::dma_dealloc(self.paddr, self.vaddr, self.pages);
         assert_eq!(err, 0, "failed to deallocate DMA");
     }
 }
 
 /// The interface which a particular hardware implementation must implement.
 pub trait Hal {
-    /// Allocates the given number of contiguous physical pages of DMA memory for virtio use.
-    fn dma_alloc(pages: usize, direction: BufferDirection) -> PhysAddr;
-    /// Deallocates the given contiguous physical DMA memory pages.
-    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32;
-    /// Converts a physical address used for virtio to a virtual address which the program can
-    /// access.
+    /// Allocates the given number of contiguous physical pages of DMA memory for VirtIO use.
     ///
-    /// This is used both for DMA regions allocated by `dma_alloc`, and for MMIO addresses within
-    /// BARs read from the device (for the PCI transport).
+    /// Returns both the physical address which the device can use to access the memory, and a
+    /// pointer to the start of it which the driver can use to access it.
+    fn dma_alloc(pages: usize, direction: BufferDirection) -> (PhysAddr, NonNull<u8>);
+    /// Deallocates the given contiguous physical DMA memory pages.
+    fn dma_dealloc(paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32;
+    /// Converts a physical address used for MMIO to a virtual address which the driver can access.
+    ///
+    /// This is only used for MMIO addresses within BARs read from the device, for the PCI
+    /// transport.
     fn phys_to_virt(paddr: PhysAddr) -> VirtAddr;
     /// Shares the given memory range with the device, and returns the physical address that the
     /// device can use to access it.

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -75,7 +75,7 @@ pub trait Hal {
     /// This is only used for MMIO addresses within BARs read from the device, for the PCI
     /// transport. It may check that the address range up to the given size is within the region
     /// expected for MMIO.
-    fn phys_to_virt(paddr: PhysAddr, size: usize) -> VirtAddr;
+    fn phys_to_virt(paddr: PhysAddr, size: usize) -> NonNull<u8>;
     /// Shares the given memory range with the device, and returns the physical address that the
     /// device can use to access it.
     ///

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -72,7 +72,7 @@ pub trait Hal {
     /// This is only used for MMIO addresses within BARs read from the device, for the PCI
     /// transport. It may check that the address range up to the given size is within the region
     /// expected for MMIO.
-    fn phys_to_virt(paddr: PhysAddr, size: usize) -> NonNull<u8>;
+    fn mmio_phys_to_virt(paddr: PhysAddr, size: usize) -> NonNull<u8>;
     /// Shares the given memory range with the device, and returns the physical address that the
     /// device can use to access it.
     ///

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -4,9 +4,6 @@ pub mod fake;
 use crate::{Error, Result, PAGE_SIZE};
 use core::{marker::PhantomData, ptr::NonNull};
 
-/// A virtual memory address in the address space of the program.
-pub type VirtAddr = usize;
-
 /// A physical address as used for virtio.
 pub type PhysAddr = usize;
 

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -32,7 +32,7 @@ impl Hal for FakeHal {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
         paddr
     }
 

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -32,8 +32,8 @@ impl Hal for FakeHal {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> VirtAddr {
-        paddr
+    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(paddr as _).unwrap()
     }
 
     fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -9,24 +9,25 @@ pub struct FakeHal;
 
 /// Fake HAL implementation for use in unit tests.
 impl Hal for FakeHal {
-    fn dma_alloc(pages: usize, _direction: BufferDirection) -> PhysAddr {
+    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (PhysAddr, NonNull<u8>) {
         assert_ne!(pages, 0);
         let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
         // Safe because the size and alignment of the layout are non-zero.
         let ptr = unsafe { alloc_zeroed(layout) };
-        if ptr.is_null() {
+        if let Some(ptr) = NonNull::new(ptr) {
+            (ptr.as_ptr() as PhysAddr, ptr)
+        } else {
             handle_alloc_error(layout);
         }
-        ptr as PhysAddr
     }
 
-    fn dma_dealloc(paddr: PhysAddr, pages: usize) -> i32 {
+    fn dma_dealloc(_paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
         assert_ne!(pages, 0);
         let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
         // Safe because the layout is the same as was used when the memory was allocated by
         // `dma_alloc` above.
         unsafe {
-            dealloc(paddr as *mut u8, layout);
+            dealloc(vaddr.as_ptr(), layout);
         }
         0
     }

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -32,7 +32,7 @@ impl Hal for FakeHal {
         0
     }
 
-    fn phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+    fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
         NonNull::new(paddr as _).unwrap()
     }
 

--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -1,6 +1,6 @@
 //! Fake HAL implementation for tests.
 
-use crate::{BufferDirection, Hal, PhysAddr, VirtAddr, PAGE_SIZE};
+use crate::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
 use core::{alloc::Layout, ptr::NonNull};
 
@@ -48,6 +48,6 @@ impl Hal for FakeHal {
     }
 }
 
-fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+fn virt_to_phys(vaddr: usize) -> PhysAddr {
     vaddr
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ mod volatile;
 
 use core::ptr::{self, NonNull};
 
-pub use self::hal::{BufferDirection, Hal, PhysAddr, VirtAddr};
+pub use self::hal::{BufferDirection, Hal, PhysAddr};
 
 /// The page size in bytes supported by the library (4 KiB).
 pub const PAGE_SIZE: usize = 0x1000;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -563,14 +563,13 @@ struct UsedElem {
 /// The fake device always uses descriptors in order.
 #[cfg(test)]
 pub(crate) fn fake_read_write_queue<const QUEUE_SIZE: usize>(
-    queue_descriptors: *const Descriptor,
+    descriptors: *const [Descriptor; QUEUE_SIZE],
     queue_driver_area: *const u8,
     queue_device_area: *mut u8,
     handler: impl FnOnce(Vec<u8>) -> Vec<u8>,
 ) {
     use core::{ops::Deref, slice};
 
-    let descriptors = ptr::slice_from_raw_parts(queue_descriptors, QUEUE_SIZE);
     let available_ring = queue_driver_area as *const AvailRing<QUEUE_SIZE>;
     let used_ring = queue_device_area as *mut UsedRing<QUEUE_SIZE>;
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::hal::VirtAddr;
 use crate::hal::{BufferDirection, Dma, Hal, PhysAddr};
 use crate::transport::Transport;
 use crate::{align_up, nonnull_slice_from_raw_parts, pages, Error, Result, PAGE_SIZE};
@@ -566,8 +564,8 @@ struct UsedElem {
 #[cfg(test)]
 pub(crate) fn fake_read_write_queue<const QUEUE_SIZE: usize>(
     queue_descriptors: *const Descriptor,
-    queue_driver_area: VirtAddr,
-    queue_device_area: VirtAddr,
+    queue_driver_area: *const u8,
+    queue_device_area: *mut u8,
     handler: impl FnOnce(Vec<u8>) -> Vec<u8>,
 ) {
     use core::{ops::Deref, slice};

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -113,8 +113,8 @@ impl State {
         assert_ne!(queue.descriptors, 0);
         fake_read_write_queue::<QUEUE_SIZE>(
             queue.descriptors as *const Descriptor,
-            queue.driver_area,
-            queue.device_area,
+            queue.driver_area as *const u8,
+            queue.device_area as *mut u8,
             |input| {
                 assert_eq!(input, Vec::new());
                 data.to_owned()
@@ -136,8 +136,8 @@ impl State {
         // Read data from the queue but don't write any response.
         fake_read_write_queue::<QUEUE_SIZE>(
             queue.descriptors as *const Descriptor,
-            queue.driver_area,
-            queue.device_area,
+            queue.driver_area as *const u8,
+            queue.device_area as *mut u8,
             |input| {
                 ret = Some(input);
                 Vec::new()
@@ -159,8 +159,8 @@ impl State {
         assert_ne!(queue.descriptors, 0);
         fake_read_write_queue::<QUEUE_SIZE>(
             queue.descriptors as *const Descriptor,
-            queue.driver_area,
-            queue.device_area,
+            queue.driver_area as *const u8,
+            queue.device_area as *mut u8,
             handler,
         )
     }

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -111,8 +111,8 @@ impl State {
     pub fn write_to_queue<const QUEUE_SIZE: usize>(&mut self, queue_index: u16, data: &[u8]) {
         let queue = &self.queues[queue_index as usize];
         assert_ne!(queue.descriptors, 0);
-        fake_read_write_queue::<QUEUE_SIZE>(
-            queue.descriptors as *const Descriptor,
+        fake_read_write_queue(
+            queue.descriptors as *const [Descriptor; QUEUE_SIZE],
             queue.driver_area as *const u8,
             queue.device_area as *mut u8,
             |input| {
@@ -134,8 +134,8 @@ impl State {
         let mut ret = None;
 
         // Read data from the queue but don't write any response.
-        fake_read_write_queue::<QUEUE_SIZE>(
-            queue.descriptors as *const Descriptor,
+        fake_read_write_queue(
+            queue.descriptors as *const [Descriptor; QUEUE_SIZE],
             queue.driver_area as *const u8,
             queue.device_area as *mut u8,
             |input| {
@@ -157,8 +157,8 @@ impl State {
     ) {
         let queue = &self.queues[queue_index as usize];
         assert_ne!(queue.descriptors, 0);
-        fake_read_write_queue::<QUEUE_SIZE>(
-            queue.descriptors as *const Descriptor,
+        fake_read_write_queue(
+            queue.descriptors as *const [Descriptor; QUEUE_SIZE],
             queue.driver_area as *const u8,
             queue.device_area as *mut u8,
             handler,

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -388,7 +388,7 @@ fn get_bar_region<H: Hal, T>(
         return Err(VirtioPciError::BarOffsetOutOfRange);
     }
     let paddr = bar_address as PhysAddr + struct_info.offset as PhysAddr;
-    let vaddr = H::phys_to_virt(paddr, struct_info.length as usize);
+    let vaddr = H::mmio_phys_to_virt(paddr, struct_info.length as usize);
     if vaddr.as_ptr() as usize % align_of::<T>() != 0 {
         return Err(VirtioPciError::Misaligned {
             vaddr,

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -388,7 +388,7 @@ fn get_bar_region<H: Hal, T>(
         return Err(VirtioPciError::BarOffsetOutOfRange);
     }
     let paddr = bar_address as PhysAddr + struct_info.offset as PhysAddr;
-    let vaddr = H::phys_to_virt(paddr);
+    let vaddr = H::phys_to_virt(paddr, struct_info.length as usize);
     if vaddr % align_of::<T>() != 0 {
         return Err(VirtioPciError::Misaligned {
             vaddr,

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -5,7 +5,7 @@ pub mod bus;
 use self::bus::{DeviceFunction, DeviceFunctionInfo, PciError, PciRoot, PCI_CAP_ID_VNDR};
 use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
-    hal::{Hal, PhysAddr, VirtAddr},
+    hal::{Hal, PhysAddr},
     nonnull_slice_from_raw_parts,
     volatile::{
         volread, volwrite, ReadOnly, Volatile, VolatileReadable, VolatileWritable, WriteOnly,
@@ -389,13 +389,13 @@ fn get_bar_region<H: Hal, T>(
     }
     let paddr = bar_address as PhysAddr + struct_info.offset as PhysAddr;
     let vaddr = H::phys_to_virt(paddr, struct_info.length as usize);
-    if vaddr % align_of::<T>() != 0 {
+    if vaddr.as_ptr() as usize % align_of::<T>() != 0 {
         return Err(VirtioPciError::Misaligned {
             vaddr,
             alignment: align_of::<T>(),
         });
     }
-    Ok(NonNull::new(vaddr as _).unwrap())
+    Ok(vaddr.cast())
 }
 
 fn get_bar_region_slice<H: Hal, T>(
@@ -433,7 +433,7 @@ pub enum VirtioPciError {
     /// The virtual address was not aligned as expected.
     Misaligned {
         /// The virtual address in question.
-        vaddr: VirtAddr,
+        vaddr: NonNull<u8>,
         /// The expected alignment in bytes.
         alignment: usize,
     },
@@ -472,7 +472,7 @@ impl Display for VirtioPciError {
             Self::BarOffsetOutOfRange => write!(f, "Capability offset greater than BAR length."),
             Self::Misaligned { vaddr, alignment } => write!(
                 f,
-                "Virtual address {:#018x} was not aligned to a {} byte boundary as expected.",
+                "Virtual address {:#018?} was not aligned to a {} byte boundary as expected.",
                 vaddr, alignment
             ),
             Self::Pci(pci_error) => pci_error.fmt(f),


### PR DESCRIPTION
The main goal of this change is to allow the `Hal` implementation to validate that the MMIO regions reported by a VirtIO device using the PCI transport is actually within the range expected by the OS. This prevents a malicious device from using bogus BARs to trick the driver into reading or writing arbitrary memory. This is important in a VM which doesn't trust its host, such as under pKVM.

`Hal::phys_to_virt` was previously being used for two different cases: for converting the physical addresses of DMA regions allocated by `Hal::dma_alloc` to virtual addresses, and for the MMIO addresses mentioned above. This PR removes the first use-case by having `Hal::dma_alloc` instead return both physical and virtual addresses for the allocated region. I've also added the virtual address as a parameter to `Hal::dma_dealloc` because it might be useful for some implementations. `Hal::phys_to_virt` is then renamed to `mmio_phys_to_virt` to reflect the only reason it is now used, and has an added size parameter so that the implementation can check that the whole region is in range.

I've also removed the `VirtAddr` type alias, because I think it makes more sense just to use a pointer everywhere that it was being used.