### PR TITLE
Allow Virtio Console driver to support multiple read requests

### DIFF
--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -155,6 +155,9 @@ impl<H: Hal, T: Transport> VirtIOConsole<'_, H, T> {
                 assert_ne!(len, 0);
                 self.cursor = 0;
                 self.pending_len = len as usize;
+                // Clear `receive_token` so that when the buffer is used up the next call to
+                // `poll_retrieve` will add a new pending request.
+                self.receive_token.take();
             }
         }
         Ok(flag)


### PR DESCRIPTION
Since the `receive_token` was never reset, the virtio console device would only ever add one request. All future calls to `poll_retrieve` would do nothing.