### PR TITLE
Add #[allow(unused_unsafe)] to remove warnings.

### DIFF
--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -21,6 +21,7 @@ unsafe impl Hal for FakeHal {
         }
     }
 
+    #[allow(unused_unsafe)]
     unsafe fn dma_dealloc(_paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
         assert_ne!(pages, 0);
         let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -116,6 +116,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
     ///
     /// The input and output buffers must remain valid and not be accessed until a call to
     /// `pop_used` with the returned token succeeds.
+    #[allow(unused_unsafe)]
     pub unsafe fn add<'a, 'b>(
         &mut self,
         inputs: &'a [&'b [u8]],
@@ -264,6 +265,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
     ///
     /// The buffers in `inputs` and `outputs` must match the set of buffers originally added to the
     /// queue by `add`.
+    #[allow(unused_unsafe)]
     unsafe fn recycle_descriptors<'a>(
         &mut self,
         head: u16,
@@ -310,6 +312,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
     ///
     /// The buffers in `inputs` and `outputs` must match the set of buffers originally added to the
     /// queue by `add` when it returned the token being passed in here.
+    #[allow(unused_unsafe)]
     pub unsafe fn pop_used<'a>(
         &mut self,
         token: u16,


### PR DESCRIPTION
This removes warnings like:
warning: unnecessary `unsafe` block