### PR TITLE
Enable unsafe_op_in_unsafe_fn lint on some modules.

### DIFF
--- a/src/hal/fake.rs
+++ b/src/hal/fake.rs
@@ -1,5 +1,7 @@
 //! Fake HAL implementation for tests.
 
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
 use core::{alloc::Layout, ptr::NonNull};


### PR DESCRIPTION
This requires the use of unsafe blocks even within unsafe functions, which makes it clearer where exactly the potential unsafety is.