### PR TITLE
Minor improvements to vsock driver

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -30,7 +30,7 @@ use virtio_drivers::{
         blk::VirtIOBlk,
         console::VirtIOConsole,
         gpu::VirtIOGpu,
-        socket::{VirtIOSocket, VsockEventType},
+        socket::{VirtIOSocket, VsockAddr, VsockEventType},
     },
     transport::{
         mmio::{MmioTransport, VirtIOHeader},
@@ -209,7 +209,13 @@ fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers::Result<()> {
     let host_cid = 2;
     let port = 1221;
     info!("Connecting to host on port {port}...");
-    socket.connect(host_cid, port, port)?;
+    socket.connect(
+        VsockAddr {
+            cid: host_cid,
+            port,
+        },
+        port,
+    )?;
     socket.wait_for_connect()?;
     info!("Connected to the host");
 

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -6,5 +6,6 @@ mod protocol;
 mod vsock;
 
 pub use error::SocketError;
+pub use protocol::VsockAddr;
 #[cfg(feature = "alloc")]
 pub use vsock::{DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -185,6 +185,11 @@ impl<H: Hal, T: Transport> VirtIOSocket<H, T> {
         })
     }
 
+    /// Returns the CID which has been assigned to this guest.
+    pub fn guest_cid(&self) -> u64 {
+        self.guest_cid
+    }
+
     /// Sends a request to connect to the given destination.
     ///
     /// This returns as soon as the request is sent; you should wait until `poll_recv` returns a
@@ -548,7 +553,7 @@ mod tests {
         };
         let socket =
             VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap();
-        assert_eq!(socket.guest_cid, 0x00_0000_0042);
+        assert_eq!(socket.guest_cid(), 0x00_0000_0042);
     }
 
     #[test]

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -207,15 +207,12 @@ impl<H: Hal, T: Transport> VirtIOSocket<H, T> {
     /// This returns as soon as the request is sent; you should wait until `poll_recv` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
-    pub fn connect(&mut self, dst_cid: u64, src_port: u32, dst_port: u32) -> Result {
+    pub fn connect(&mut self, destination: VsockAddr, src_port: u32) -> Result {
         if self.connection_info.is_some() {
             return Err(SocketError::ConnectionExists.into());
         }
         let new_connection_info = ConnectionInfo {
-            dst: VsockAddr {
-                cid: dst_cid,
-                port: dst_port,
-            },
+            dst: destination,
             src_port,
             ..Default::default()
         };
@@ -607,6 +604,10 @@ mod tests {
         let guest_cid = 66;
         let host_port = 1234;
         let guest_port = 4321;
+        let host_address = VsockAddr {
+            cid: host_cid,
+            port: host_port,
+        };
         let hello_from_guest = "Hello from guest";
         let hello_from_host = "Hello from host";
 
@@ -807,7 +808,7 @@ mod tests {
             );
         });
 
-        socket.connect(host_cid, guest_port, host_port).unwrap();
+        socket.connect(host_address, guest_port).unwrap();
         socket.wait_for_connect().unwrap();
         socket.send(hello_from_guest.as_bytes()).unwrap();
         let mut buffer = [0u8; 64];


### PR DESCRIPTION
In particular:

* Changed the `VirtIOSocket::connect` method to take a `VsockAddr` rather than separate CID and port. The `VsockAddr` was already used in `VsockEvent` so this is more consistent.
* `VirtIOSocket::new` to allocate buffers for the RX virtqueue individually rather than allocating one big buffer and splitting it. This makes the code a bit simpler, and also may make allocation easier as the allocator doesn't have to find such a large contiguous memory range.
* Added `VirtIOSocket::guest_cid` method to get the CID assigned to the VM.