### PR TITLE
Copy data back and forth to new buffer in fake HAL share.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ zerocopy = "0.6.1"
 [features]
 default = ["alloc"]
 alloc = ["zerocopy/alloc"]
+
+[dev-dependencies]
+zerocopy = { version = "0.6.1", features = ["alloc"] }


### PR DESCRIPTION
This helps ensure in tests that drivers aren't sharing with the wrong direction or forgetting to unshare. Drivers (or queue implementations) which do this would pass tests but fail to work properly when used with a HAL implementation which actually requires sharing and unsharing buffers with the device.