### PR TITLE
Add support for indirect descriptors in VirtQueue with alloc feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ VirtIO guest drivers in Rust. For **no_std** environment.
 
 | Feature flag                 | Supported |                                         |
 | ---------------------------- | --------- | --------------------------------------- |
-| `VIRTIO_F_INDIRECT_DESC`     | ❌        | Indirect descriptors                    |
+| `VIRTIO_F_INDIRECT_DESC`     | ✅        | Indirect descriptors                    |
 | `VIRTIO_F_EVENT_IDX`         | ❌        | `avail_event` and `used_event` fields   |
 | `VIRTIO_F_VERSION_1`         | TODO      | VirtIO version 1 compliance             |
 | `VIRTIO_F_ACCESS_PLATFORM`   | ❌        | Limited device access to memory         |

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -68,7 +68,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         };
         info!("found a block device of size {}KB", capacity / 2);
 
-        let queue = VirtQueue::new(&mut transport, QUEUE)?;
+        let queue = VirtQueue::new(&mut transport, QUEUE, false)?;
         transport.finish_init();
 
         Ok(VirtIOBlk {

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -607,7 +607,7 @@ mod tests {
         let transport = FakeTransport {
             device_type: DeviceType::Block,
             max_queue_size: QUEUE_SIZE.into(),
-            device_features: 0,
+            device_features: BlkFeature::RING_INDIRECT_DESC.bits(),
             config_space: NonNull::from(&mut config_space),
             state: state.clone(),
         };
@@ -677,7 +677,7 @@ mod tests {
         let transport = FakeTransport {
             device_type: DeviceType::Block,
             max_queue_size: QUEUE_SIZE.into(),
-            device_features: 0,
+            device_features: BlkFeature::RING_INDIRECT_DESC.bits(),
             config_space: NonNull::from(&mut config_space),
             state: state.clone(),
         };
@@ -752,7 +752,7 @@ mod tests {
         let transport = FakeTransport {
             device_type: DeviceType::Block,
             max_queue_size: QUEUE_SIZE.into(),
-            device_features: BlkFeature::FLUSH.bits(),
+            device_features: (BlkFeature::RING_INDIRECT_DESC | BlkFeature::FLUSH).bits(),
             config_space: NonNull::from(&mut config_space),
             state: state.clone(),
         };
@@ -819,7 +819,7 @@ mod tests {
         let transport = FakeTransport {
             device_type: DeviceType::Block,
             max_queue_size: QUEUE_SIZE.into(),
-            device_features: 0,
+            device_features: BlkFeature::RING_INDIRECT_DESC.bits(),
             config_space: NonNull::from(&mut config_space),
             state: state.clone(),
         };

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -72,8 +72,8 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
             (features & supported_features).bits()
         });
         let config_space = transport.config_space::<Config>()?;
-        let receiveq = VirtQueue::new(&mut transport, QUEUE_RECEIVEQ_PORT_0)?;
-        let transmitq = VirtQueue::new(&mut transport, QUEUE_TRANSMITQ_PORT_0)?;
+        let receiveq = VirtQueue::new(&mut transport, QUEUE_RECEIVEQ_PORT_0, false)?;
+        let transmitq = VirtQueue::new(&mut transport, QUEUE_TRANSMITQ_PORT_0, false)?;
 
         // Safe because no alignment or initialisation is required for [u8], the DMA buffer is
         // dereferenceable, and the lifetime of the reference matches the lifetime of the DMA buffer

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -57,8 +57,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             );
         }
 
-        let control_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT)?;
-        let cursor_queue = VirtQueue::new(&mut transport, QUEUE_CURSOR)?;
+        let control_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT, false)?;
+        let cursor_queue = VirtQueue::new(&mut transport, QUEUE_CURSOR, false)?;
 
         let queue_buf_send = FromBytes::new_box_slice_zeroed(PAGE_SIZE);
         let queue_buf_recv = FromBytes::new_box_slice_zeroed(PAGE_SIZE);

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -38,8 +38,8 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
 
         let config = transport.config_space::<Config>()?;
 
-        let mut event_queue = VirtQueue::new(&mut transport, QUEUE_EVENT)?;
-        let status_queue = VirtQueue::new(&mut transport, QUEUE_STATUS)?;
+        let mut event_queue = VirtQueue::new(&mut transport, QUEUE_EVENT, false)?;
+        let status_queue = VirtQueue::new(&mut transport, QUEUE_STATUS, false)?;
         for (i, event) in event_buf.as_mut().iter_mut().enumerate() {
             // Safe because the buffer lasts as long as the queue.
             let token = unsafe { event_queue.add(&[], &mut [event.as_bytes_mut()])? };

--- a/src/device/net.rs
+++ b/src/device/net.rs
@@ -139,8 +139,8 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONet<H, T, QUEUE_SIZE> 
             return Err(Error::InvalidParam);
         }
 
-        let send_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT)?;
-        let mut recv_queue = VirtQueue::new(&mut transport, QUEUE_RECEIVE)?;
+        let send_queue = VirtQueue::new(&mut transport, QUEUE_TRANSMIT, false)?;
+        let mut recv_queue = VirtQueue::new(&mut transport, QUEUE_RECEIVE, false)?;
 
         const NONE_BUF: Option<RxBuffer> = None;
         let mut rx_buffers = [NONE_BUF; QUEUE_SIZE];

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -257,9 +257,9 @@ impl<H: Hal, T: Transport> VirtIOSocket<H, T> {
         };
         debug!("guest cid: {guest_cid:?}");
 
-        let mut rx = VirtQueue::new(&mut transport, RX_QUEUE_IDX)?;
-        let tx = VirtQueue::new(&mut transport, TX_QUEUE_IDX)?;
-        let event = VirtQueue::new(&mut transport, EVENT_QUEUE_IDX)?;
+        let mut rx = VirtQueue::new(&mut transport, RX_QUEUE_IDX, false)?;
+        let tx = VirtQueue::new(&mut transport, TX_QUEUE_IDX, false)?;
+        let event = VirtQueue::new(&mut transport, EVENT_QUEUE_IDX, false)?;
 
         // Allocate and add buffers for the RX queue.
         let mut rx_queue_buffers = [null_mut(); QUEUE_SIZE];


### PR DESCRIPTION
This is based on some of the work in #96, but fixes some issues there with how allocation and DMA memory is handled, adds tests for the indirect virtqueue itself, and also adds support to the fake device support so that device tests will work with indirect queues.

Devices can choose when constructing a `VirtQueue` whether it should support indirect descriptors or not, based on their preference and the device features. For now only the `VirtIOBlk` driver uses indirect descriptors (if the underlying device supports it). If a `VirtQueue` is constructed with indirect descriptor support then it will use them whenever more than one buffer is added to the queue. There's no point using indirect descriptors for a single buffer so we don't bother.

Space for the indirect descriptor lists is allocated (and shared with the device via the HAL) dynamically. This means that it depends on the `alloc` feature, which is enabled by default. If the `alloc` feature is disabled, then indirect descriptors will never be used.