### PR TITLE
Support reading or writing more than one block at once.

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -156,8 +156,8 @@ fn virtio_blk<T: Transport>(transport: T) {
         for x in input.iter_mut() {
             *x = i as u8;
         }
-        blk.write_block(i, &input).expect("failed to write");
-        blk.read_block(i, &mut output).expect("failed to read");
+        blk.write_blocks(i, &input).expect("failed to write");
+        blk.read_blocks(i, &mut output).expect("failed to read");
         assert_eq!(input, output);
     }
     info!("virtio-blk test finished");

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -98,8 +98,8 @@ fn virtio_blk<T: Transport>(transport: T) {
         for x in input.iter_mut() {
             *x = i as u8;
         }
-        blk.write_block(i, &input).expect("failed to write");
-        blk.read_block(i, &mut output).expect("failed to read");
+        blk.write_blocks(i, &input).expect("failed to write");
+        blk.read_blocks(i, &mut output).expect("failed to read");
         assert_eq!(input, output);
     }
     info!("virtio-blk test finished");

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -80,8 +80,8 @@ fn virtio_blk<T: Transport>(transport: T) {
         for x in input.iter_mut() {
             *x = i as u8;
         }
-        blk.write_block(i, &input).expect("failed to write");
-        blk.read_block(i, &mut output).expect("failed to read");
+        blk.write_blocks(i, &input).expect("failed to write");
+        blk.read_blocks(i, &mut output).expect("failed to read");
         assert_eq!(input, output);
     }
     info!("virtio-blk test finished");


### PR DESCRIPTION
The VirtIO block device specification allows more than one block to be read or written at a time, so there's no reason to limit our implementation to a single block.

I've kept it to just a single buffer for all blocks. Supporting multiple buffers in the same request would require either allocation, or maybe somehow refactoring `VirtQueue::add_notify_wait_pop` to take iterators for the buffers rather than slices.