### PR TITLE
[vsock] Add method to send credit update manually

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -227,7 +227,7 @@ fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers::Result<()> {
     for k in 0..EXCHANGE_NUM {
         let mut buffer = [0u8; 24];
         let socket_event = socket.wait_for_event()?;
-        let VsockEventType::Received {length, ..} = socket_event.event_type else {
+        let VsockEventType::Received { length, .. } = socket_event.event_type else {
             panic!("Received unexpected socket event {:?}", socket_event);
         };
         let read_length = socket.recv(host_address, port, &mut buffer)?;

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -525,7 +525,7 @@ mod tests {
                 .unwrap()
                 .write_to_queue::<QUEUE_SIZE>(RX_QUEUE_IDX, &response);
 
-            // Expects a credit update.
+            // Expect a credit update.
             State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
             assert_eq!(
                 VirtioVsockHdr::read_from(
@@ -549,7 +549,7 @@ mod tests {
                     fwd_cnt: (hello_from_host.len() as u32).into(),
                 }
             );
-            // Expects a shutdown.
+            // Expect a shutdown.
             State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
             assert_eq!(
                 VirtioVsockHdr::read_from(

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -525,7 +525,7 @@ mod tests {
                 .unwrap()
                 .write_to_queue::<QUEUE_SIZE>(RX_QUEUE_IDX, &response);
 
-            // Expect a credit update.
+            // Expects a credit update.
             State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
             assert_eq!(
                 VirtioVsockHdr::read_from(

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -213,6 +213,7 @@ impl<H: Hal, T: Transport> VsockConnectionManager<H, T> {
 
         // Copy from ring buffer
         let bytes_read = connection.buffer.drain(buffer);
+
         connection.info.done_forwarding(bytes_read);
 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
@@ -223,6 +224,12 @@ impl<H: Hal, T: Transport> VsockConnectionManager<H, T> {
         }
 
         Ok(bytes_read)
+    }
+
+    /// Returns whether the receive buffer is empty.
+    pub fn is_recv_buffer_empty(&mut self, peer: VsockAddr, src_port: u32) -> Result<bool> {
+        let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+        Ok(connection.buffer.is_empty())
     }
 
     /// Sends a credit update to the given peer.

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -226,10 +226,10 @@ impl<H: Hal, T: Transport> VsockConnectionManager<H, T> {
         Ok(bytes_read)
     }
 
-    /// Returns whether the receive buffer is empty.
-    pub fn is_recv_buffer_empty(&mut self, peer: VsockAddr, src_port: u32) -> Result<bool> {
+    /// Returns the number of bytes currently available in the recv buffer.
+    pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
-        Ok(connection.buffer.is_empty())
+        Ok(connection.buffer.available())
     }
 
     /// Sends a credit update to the given peer.

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -213,8 +213,10 @@ impl<H: Hal, T: Transport> VsockConnectionManager<H, T> {
 
         // Copy from ring buffer
         let bytes_read = connection.buffer.drain(buffer);
-
-        connection.info.done_forwarding(bytes_read);
+        if bytes_read > 0 {
+            connection.info.done_forwarding(bytes_read);
+            self.driver.credit_update(&connection.info)?;
+        }
 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.


### PR DESCRIPTION
This PR addresses a bug in the vsock connection manager. Prior to the PR, the guest doesn't update the host after it processes the local buffer. As a result, when the receiving message length reaches the buffer capacity, the host could mistakenly stop sending the message, unaware that the guest still had available buffer.

This fix ensures that the credit is correctly updated after processing the local buffer, allowing for continuous message transmission between the host and the guest.