### PR TITLE
Rename RingBuffer#available to free.

### DIFF
--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -333,7 +333,7 @@ impl RingBuffer {
     }
 
     /// Returns the number of bytes currently free in the buffer.
-    pub fn available(&self) -> usize {
+    pub fn free(&self) -> usize {
         self.buffer.len() - self.used
     }
 
@@ -341,7 +341,7 @@ impl RingBuffer {
     ///
     /// Returns true if they were added, or false if they were not.
     pub fn add(&mut self, bytes: &[u8]) -> bool {
-        if bytes.len() > self.available() {
+        if bytes.len() > self.free() {
             return false;
         }
 


### PR DESCRIPTION
This avoids using the same name as recv_buffer_available_bytes.