### PR TITLE
ci: turn on tcp feature in examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
+      - uses: actions/checkout@v4
       - name: Check code format
         uses: actions-rs/cargo@v1
         with:
@@ -28,11 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: actions/checkout@v4
       - name: Build with no features
         uses: actions-rs/cargo@v1
         with:
@@ -69,27 +60,15 @@ jobs:
           - x86_64
         include:
           - example: aarch64
-            toolchain: stable
-            target: aarch64-unknown-none
             packages: qemu-system-arm gcc-aarch64-linux-gnu
           - example: riscv
-            toolchain: nightly-2022-11-03
-            target: riscv64imac-unknown-none-elf
             packages: qemu-system-misc
           - example: x86_64
-            toolchain: nightly
-            target: x86_64-unknown-none
             packages: qemu-system-x86
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install QEMU
         run: sudo apt update && sudo apt install ${{ matrix.packages }} && sudo chmod 666 /dev/vhost-vsock
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
-          components: llvm-tools-preview, rustfmt
       - name: Check code format
         working-directory: examples/${{ matrix.example }}
         run: cargo fmt --all -- --check

--- a/examples/aarch64/rust-toolchain.toml
+++ b/examples/aarch64/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["rustfmt", "llvm-tools"]
 targets = ["aarch64-unknown-none"]
 profile = "minimal"

--- a/examples/aarch64/rust-toolchain.toml
+++ b/examples/aarch64/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "llvm-tools"]
+targets = ["aarch64-unknown-none"]
+profile = "minimal"

--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -4,7 +4,7 @@ mode := release
 kernel := target/$(target)/$(mode)/riscv
 img := target/$(target)/$(mode)/img
 
-tcp ?= off
+tcp ?= on
 
 sysroot := $(shell rustc --print sysroot)
 objdump := $(shell find $(sysroot) -name llvm-objdump) --arch-name=$(arch)

--- a/examples/riscv/rust-toolchain
+++ b/examples/riscv/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/examples/riscv/rust-toolchain
+++ b/examples/riscv/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-11-03
+nightly

--- a/examples/riscv/rust-toolchain.toml
+++ b/examples/riscv/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "llvm-tools"]
+targets = ["riscv64imac-unknown-none-elf"]
+profile = "minimal"

--- a/examples/riscv/src/tcp.rs
+++ b/examples/riscv/src/tcp.rs
@@ -175,6 +175,7 @@ pub fn test_echo_server<T: Transport>(dev: DeviceImpl<T>) {
         } else if socket.may_send() {
             info!("tcp:{} close", PORT);
             socket.close();
+            break;
         }
     }
 }

--- a/examples/riscv/src/tcp.rs
+++ b/examples/riscv/src/tcp.rs
@@ -9,7 +9,7 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 use smoltcp::{socket::tcp, time::Instant};
-use virtio_drivers::device::net::{NetBuffer, VirtIONet};
+use virtio_drivers::device::net::{RxBuffer, VirtIONet};
 use virtio_drivers::{transport::Transport, Error};
 
 use super::{HalImpl, NET_QUEUE_SIZE};
@@ -64,7 +64,7 @@ impl<T: Transport> Device for DeviceWrapper<T> {
     }
 }
 
-struct VirtioRxToken<T: Transport>(Rc<RefCell<DeviceImpl<T>>>, NetBuffer);
+struct VirtioRxToken<T: Transport>(Rc<RefCell<DeviceImpl<T>>>, RxBuffer);
 struct VirtioTxToken<T: Transport>(Rc<RefCell<DeviceImpl<T>>>);
 
 impl<T: Transport> RxToken for VirtioRxToken<T> {

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -4,7 +4,7 @@ mode := release
 kernel := target/$(target)/$(mode)/$(arch)
 img := target/$(target)/$(mode)/img
 accel ?= on
-tcp ?= off
+tcp ?= on
 
 sysroot := $(shell rustc --print sysroot)
 objdump := $(shell find $(sysroot) -name llvm-objdump) --arch-name=$(arch)

--- a/examples/x86_64/rust-toolchain
+++ b/examples/x86_64/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/examples/x86_64/rust-toolchain.toml
+++ b/examples/x86_64/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "llvm-tools"]
+targets = ["x86_64-unknown-none"]
+profile = "minimal"

--- a/examples/x86_64/src/tcp.rs
+++ b/examples/x86_64/src/tcp.rs
@@ -92,6 +92,7 @@ impl<T: Transport> TxToken for VirtioTxToken<T> {
         let mut dev = self.0.borrow_mut();
         let mut tx_buf = dev.new_tx_buffer(len);
         let result = f(tx_buf.packet_mut());
+        trace!("SEND {} bytes: {:02X?}", len, tx_buf.packet());
         dev.send(tx_buf).unwrap();
         result
     }

--- a/examples/x86_64/src/tcp.rs
+++ b/examples/x86_64/src/tcp.rs
@@ -92,8 +92,7 @@ impl<T: Transport> TxToken for VirtioTxToken<T> {
         let mut dev = self.0.borrow_mut();
         let mut tx_buf = dev.new_tx_buffer(len);
         let result = f(tx_buf.packet_mut());
-        trace!("SEND {} bytes: {:02X?}", len, tx_buf.packet());
-        dev.transmit(tx_buf).unwrap();
+        dev.send(tx_buf).unwrap();
         result
     }
 }
@@ -176,6 +175,7 @@ pub fn test_echo_server<T: Transport>(dev: DeviceImpl<T>) {
         } else if socket.may_send() {
             info!("tcp:{} close", PORT);
             socket.close();
+            break;
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
When I was testing the x86_64 example with `tcp` feature, I got a compilation error at the line of `dev.transmit(tx_buf).unwrap();`.

The error was introduced in a recent PR: https://github.com/rcore-os/virtio-drivers/pull/111.
It was overlooked by CI because the default value `tcp=off` was in effect.

I found the original rationale for disabling `tcp` in CI from this commit message: https://github.com/rcore-os/virtio-drivers/pull/86/commits/5b0786b09ec94840ad181818be72ba62d217dee0
>Disable tcp feature in x86_64 example by default.
> It waits forever, which is no good in CI.

So I modify the `test_echo_server` function to break out the dead loop.

I also applied the same fix to the riscv example.