### PR TITLE
Add typed getters for input device config space

### DIFF
--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -7,6 +7,7 @@ use crate::transport::Transport;
 use crate::volatile::{volread, volwrite, ReadOnly, VolatileReadable, WriteOnly};
 use crate::Result;
 use alloc::boxed::Box;
+use core::cmp::min;
 use core::ptr::{addr_of, NonNull};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
@@ -112,8 +113,8 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             volwrite!(self.config, select, select as u8);
             volwrite!(self.config, subsel, subsel);
             size = volread!(self.config, size);
-            for i in 0..size {
-                let i = usize::from(i);
+            let size_to_copy = min(usize::from(size), out.len());
+            for i in 0..size_to_copy {
                 out[i] = addr_of!((*self.config.as_ptr()).data[i]).vread();
             }
         }

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -249,7 +249,7 @@ struct Config {
     select: WriteOnly<u8>,
     subsel: WriteOnly<u8>,
     size: ReadOnly<u8>,
-    _reversed: [ReadOnly<u8>; 5],
+    _reserved: [ReadOnly<u8>; 5],
     data: [ReadOnly<u8>; 128],
 }
 

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -302,3 +302,92 @@ const SUPPORTED_FEATURES: Feature = Feature::RING_EVENT_IDX.union(Feature::RING_
 
 // a parameter that can change
 const QUEUE_SIZE: usize = 32;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        hal::fake::FakeHal,
+        transport::{
+            fake::{FakeTransport, QueueStatus, State},
+            DeviceType,
+        },
+    };
+    use alloc::{sync::Arc, vec};
+    use core::convert::TryInto;
+    use std::sync::Mutex;
+
+    #[test]
+    fn config() {
+        const DEFAULT_DATA: ReadOnly<u8> = ReadOnly::new(0);
+        let mut config_space = Config {
+            select: WriteOnly::default(),
+            subsel: WriteOnly::default(),
+            size: ReadOnly::new(0),
+            _reserved: Default::default(),
+            data: [DEFAULT_DATA; 128],
+        };
+        let state = Arc::new(Mutex::new(State {
+            queues: vec![QueueStatus::default(), QueueStatus::default()],
+            ..Default::default()
+        }));
+        let transport = FakeTransport {
+            device_type: DeviceType::Block,
+            max_queue_size: QUEUE_SIZE.try_into().unwrap(),
+            device_features: 0,
+            config_space: NonNull::from(&mut config_space),
+            state: state.clone(),
+        };
+        let mut input = VirtIOInput::<FakeHal, FakeTransport<Config>>::new(transport).unwrap();
+
+        set_data(&mut config_space, "Test input device".as_bytes());
+        assert_eq!(input.name().unwrap(), "Test input device");
+        assert_eq!(config_space.select.0, InputConfigSelect::IdName as u8);
+        assert_eq!(config_space.subsel.0, 0);
+
+        set_data(&mut config_space, "Serial number".as_bytes());
+        assert_eq!(input.serial_number().unwrap(), "Serial number");
+        assert_eq!(config_space.select.0, InputConfigSelect::IdSerial as u8);
+        assert_eq!(config_space.subsel.0, 0);
+
+        let ids = DevIDs {
+            bustype: 0x4242,
+            product: 0x0067,
+            vendor: 0x1234,
+            version: 0x4321,
+        };
+        set_data(&mut config_space, ids.as_bytes());
+        assert_eq!(input.ids().unwrap(), ids);
+        assert_eq!(config_space.select.0, InputConfigSelect::IdDevids as u8);
+        assert_eq!(config_space.subsel.0, 0);
+
+        set_data(&mut config_space, &[0x12, 0x34, 0x56]);
+        assert_eq!(input.prop_bits().as_ref(), &[0x12, 0x34, 0x56]);
+        assert_eq!(config_space.select.0, InputConfigSelect::PropBits as u8);
+        assert_eq!(config_space.subsel.0, 0);
+
+        set_data(&mut config_space, &[0x42, 0x66]);
+        assert_eq!(input.ev_bits(3).as_ref(), &[0x42, 0x66]);
+        assert_eq!(config_space.select.0, InputConfigSelect::EvBits as u8);
+        assert_eq!(config_space.subsel.0, 3);
+
+        let abs_info = AbsInfo {
+            min: 12,
+            max: 1234,
+            fuzz: 4,
+            flat: 10,
+            res: 2,
+        };
+        set_data(&mut config_space, abs_info.as_bytes());
+        assert_eq!(input.abs_info(5).unwrap(), abs_info);
+        assert_eq!(config_space.select.0, InputConfigSelect::AbsInfo as u8);
+        assert_eq!(config_space.subsel.0, 5);
+    }
+
+    fn set_data(config_space: &mut Config, value: &[u8]) {
+        config_space.size.0 = value.len().try_into().unwrap();
+        for (i, &byte) in value.into_iter().enumerate() {
+            config_space.data[i].0 = byte;
+        }
+    }
+}

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -118,8 +118,8 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             volwrite!(self.config, subsel, subsel);
             size = volread!(self.config, size);
             let size_to_copy = min(usize::from(size), out.len());
-            for i in 0..size_to_copy {
-                out[i] = addr_of!((*self.config.as_ptr()).data[i]).vread();
+            for (i, out_item) in out.iter_mut().take(size_to_copy).enumerate() {
+                *out_item = addr_of!((*self.config.as_ptr()).data[i]).vread();
             }
         }
         size

--- a/src/device/net/mod.rs
+++ b/src/device/net/mod.rs
@@ -64,7 +64,8 @@ bitflags! {
         const CTRL_RX = 1 << 18;
         /// Control channel VLAN filtering.
         const CTRL_VLAN = 1 << 19;
-        ///
+        /// Device supports VIRTIO_NET_CTRL_RX_ALLUNI, VIRTIO_NET_CTRL_RX_NOMULTI,
+        /// VIRTIO_NET_CTRL_RX_NOUNI and VIRTIO_NET_CTRL_RX_NOBCAST.
         const CTRL_RX_EXTRA = 1 << 20;
         /// Driver can send gratuitous packets.
         const GUEST_ANNOUNCE = 1 << 21;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,13 @@ pub enum Error {
     SocketDeviceError(device::socket::SocketError),
 }
 
+#[cfg(feature = "alloc")]
+impl From<alloc::string::FromUtf8Error> for Error {
+    fn from(_value: alloc::string::FromUtf8Error) -> Self {
+        Self::IoError
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -5,7 +5,7 @@ pub struct ReadOnly<T: Copy>(T);
 
 impl<T: Copy> ReadOnly<T> {
     /// Construct a new instance for testing.
-    pub fn new(value: T) -> Self {
+    pub const fn new(value: T) -> Self {
         Self(value)
     }
 }
@@ -22,7 +22,7 @@ pub struct Volatile<T: Copy>(T);
 
 impl<T: Copy> Volatile<T> {
     /// Construct a new instance for testing.
-    pub fn new(value: T) -> Self {
+    pub const fn new(value: T) -> Self {
         Self(value)
     }
 }

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -1,7 +1,7 @@
 /// An MMIO register which can only be read from.
 #[derive(Default)]
 #[repr(transparent)]
-pub struct ReadOnly<T: Copy>(T);
+pub struct ReadOnly<T: Copy>(pub(crate) T);
 
 impl<T: Copy> ReadOnly<T> {
     /// Construct a new instance for testing.
@@ -13,7 +13,7 @@ impl<T: Copy> ReadOnly<T> {
 /// An MMIO register which can only be written to.
 #[derive(Default)]
 #[repr(transparent)]
-pub struct WriteOnly<T: Copy>(T);
+pub struct WriteOnly<T: Copy>(pub(crate) T);
 
 /// An MMIO register which may be both read and written.
 #[derive(Default)]


### PR DESCRIPTION
Rather than just adding bytes to a buffer, these return the appropriate type for the selector.

The size of the data available for a particular selector is given by the device, so only read that much data rather than the full 128 bytes every time.