### PR TITLE
Make types needed to use `VirtIOSocket` public.

### DIFF
--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -17,9 +17,9 @@ mod vsock;
 #[cfg(feature = "alloc")]
 pub use connectionmanager::VsockConnectionManager;
 pub use error::SocketError;
-pub use protocol::{VsockAddr, VMADDR_CID_HOST};
+pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]
-pub use vsock::{DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
+pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
 
 /// The size in bytes of each buffer used in the RX virtqueue. This must be bigger than
 /// `size_of::<VirtioVsockHdr>()`.

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -24,9 +24,12 @@ const EVENT_QUEUE_IDX: u16 = 2;
 pub(crate) const QUEUE_SIZE: usize = 8;
 const SUPPORTED_FEATURES: Feature = Feature::RING_EVENT_IDX.union(Feature::RING_INDIRECT_DESC);
 
+/// Information about a particular vsock connection.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ConnectionInfo {
+    /// The address of the peer.
     pub dst: VsockAddr,
+    /// The local port number associated with the connection.
     pub src_port: u32,
     /// The last `buf_alloc` value the peer sent to us, indicating how much receive buffer space in
     /// bytes it has allocated for packet bodies.
@@ -49,6 +52,8 @@ pub struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
+    /// Creates a new `ConnectionInfo` for the given peer address and local port, and default values
+    /// for everything else.
     pub fn new(destination: VsockAddr, src_port: u32) -> Self {
         Self {
             dst: destination,


### PR DESCRIPTION
Some of the types used in methods on `VirtIOSocket` were private, despite the methods being part of the crate's public API. They should also be public so that people can use the methods.