### PR TITLE
Use `flat_device_tree` crate for examples

### DIFF
--- a/examples/aarch64/Cargo.toml
+++ b/examples/aarch64/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 buddy_system_allocator = "0.9.0"
-fdt = "0.1.5"
+flat_device_tree = "3.1.1"
 log = "0.4.17"
 smccc = "0.1.1"
 spin = "0.9.8"

--- a/examples/aarch64/Cargo.toml
+++ b/examples/aarch64/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Andrew Walbran <qwandor@google.com>"]
 edition = "2021"
 
 [dependencies]
-buddy_system_allocator = "0.9.0"
+buddy_system_allocator = "0.10.0"
 flat_device_tree = "3.1.1"
-log = "0.4.17"
+log = "0.4.22"
 smccc = "0.1.1"
 spin = "0.9.8"
 virtio-drivers = { path = "../.." }

--- a/examples/aarch64/Makefile
+++ b/examples/aarch64/Makefile
@@ -110,7 +110,7 @@ crosvm: $(kernel_crosvm_bin) $(img)
 	adb shell 'mkdir -p /data/local/tmp/virt_raw'
 	adb push $(kernel_crosvm_bin) /data/local/tmp/virt_raw/aarch64_example
 	adb push $(img) /data/local/tmp/virt_raw/disk_img
-	adb shell "/data/local/tmp/crosvm --log-level=trace --extended-status run --disable-sandbox --serial=stdout,hardware=serial,num=1 --rwdisk=/data/local/tmp/virt_raw/disk_img --bios=/data/local/tmp/virt_raw/aarch64_example"
+	adb shell "/apex/com.android.virt/bin/crosvm --log-level=info --extended-status run --disable-sandbox --serial=stdout,hardware=serial,num=1 --rwdisk=/data/local/tmp/virt_raw/disk_img --bios=/data/local/tmp/virt_raw/aarch64_example"
 
 $(img):
 	dd if=/dev/zero of=$@ bs=512 count=32

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -335,7 +335,7 @@ impl PciMemory32Allocator {
         let mut memory_32_size = 0;
         for i in 0..ranges.value.len() / 28 {
             let range = &ranges.value[i * 28..(i + 1) * 28];
-            let prefetchable = range[0] & 0x80 != 0;
+            let prefetchable = range[0] & 0x40 != 0;
             let range_type = PciRangeType::from(range[0] & 0x3);
             let bus_address = u64::from_be_bytes(range[4..12].try_into().unwrap());
             let cpu_physical = u64::from_be_bytes(range[12..20].try_into().unwrap());

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -267,8 +267,8 @@ enum PciRangeType {
     Memory64,
 }
 
-impl From<u8> for PciRangeType {
-    fn from(value: u8) -> Self {
+impl From<u32> for PciRangeType {
+    fn from(value: u32) -> Self {
         match value {
             0 => Self::ConfigurationSpace,
             1 => Self::IoSpace,
@@ -324,18 +324,14 @@ struct PciMemory32Allocator {
 impl PciMemory32Allocator {
     /// Creates a new allocator based on the ranges property of the given PCI node.
     pub fn for_pci_ranges(pci_node: &FdtNode) -> Self {
-        let ranges = pci_node
-            .property("ranges")
-            .expect("PCI node missing ranges property.");
         let mut memory_32_address = 0;
         let mut memory_32_size = 0;
-        for i in 0..ranges.value.len() / 28 {
-            let range = &ranges.value[i * 28..(i + 1) * 28];
-            let prefetchable = range[0] & 0x40 != 0;
-            let range_type = PciRangeType::from(range[0] & 0x3);
-            let bus_address = u64::from_be_bytes(range[4..12].try_into().unwrap());
-            let cpu_physical = u64::from_be_bytes(range[12..20].try_into().unwrap());
-            let size = u64::from_be_bytes(range[20..28].try_into().unwrap());
+        for range in pci_node.ranges() {
+            let prefetchable = range.child_bus_address_hi & 0x4000_0000 != 0;
+            let range_type = PciRangeType::from((range.child_bus_address_hi & 0x0300_0000) >> 24);
+            let bus_address = range.child_bus_address as u64;
+            let cpu_physical = range.parent_bus_address as u64;
+            let size = range.size as u64;
             info!(
                 "range: {:?} {}prefetchable bus address: {:#018x} host physical address: {:#018x} size: {:#018x}",
                 range_type,

--- a/examples/riscv/Cargo.toml
+++ b/examples/riscv/Cargo.toml
@@ -14,7 +14,7 @@ default = ["tcp"]
 log = "0.4"
 riscv = "0.10"
 opensbi-rt = { git = "https://github.com/rcore-os/opensbi-rt.git", rev = "abdfeb72" }
-fdt = "0.1.4"
+flat_device_tree = "3.1.1"
 virtio-drivers = { path = "../.." }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -10,7 +10,7 @@ extern crate opensbi_rt;
 
 use alloc::vec;
 use core::ptr::NonNull;
-use fdt::{node::FdtNode, standard_nodes::Compatible, Fdt};
+use flat_device_tree::{node::FdtNode, standard_nodes::Compatible, Fdt};
 use log::LevelFilter;
 use virtio_drivers::{
     device::{
@@ -58,7 +58,7 @@ fn walk_dt(fdt: Fdt) {
 }
 
 fn virtio_probe(node: FdtNode) {
-    if let Some(reg) = node.reg().and_then(|mut reg| reg.next()) {
+    if let Some(reg) = node.reg().next() {
         let paddr = reg.starting_address as usize;
         let size = reg.size.unwrap();
         let vaddr = paddr;


### PR DESCRIPTION
The `fdt` crate hasn't been updated in a while, `flat_device_tree` is a fork with an improved API. I also fixed a bug which got the prefetchable attribute for PCI ranges from the wrong bit.