### PR TITLE
Add methods to Transport to read and write config space, rather than returning a pointer.

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -209,7 +209,7 @@ fn virtio_net<T: Transport>(transport: T) {
 fn virtio_console<T: Transport>(transport: T) {
     let mut console =
         VirtIOConsole::<HalImpl, T>::new(transport).expect("Failed to create console driver");
-    if let Some(size) = console.size() {
+    if let Some(size) = console.size().unwrap() {
         info!("VirtIO console {}", size);
     }
     for &c in b"Hello world on console!\n" {

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -56,9 +56,9 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
 
         // Read configuration space.
-        let capacity = transport.read_config_space::<u32>(offset_of!(BlkConfig, capacity_low))
+        let capacity = transport.read_config_space::<u32>(offset_of!(BlkConfig, capacity_low))?
             as u64
-            | (transport.read_config_space::<u32>(offset_of!(BlkConfig, capacity_high)) as u64)
+            | (transport.read_config_space::<u32>(offset_of!(BlkConfig, capacity_high))? as u64)
                 << 32;
         info!("found a block device of size {}KB", capacity / 2);
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -3,10 +3,11 @@
 use crate::hal::{BufferDirection, Dma, Hal};
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use crate::volatile::{volread, ReadOnly, Volatile, WriteOnly};
+use crate::volatile::{ReadOnly, Volatile, WriteOnly};
 use crate::{pages, Error, Result, PAGE_SIZE};
 use alloc::boxed::Box;
 use bitflags::bitflags;
+use core::mem::offset_of;
 use log::info;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
@@ -43,15 +44,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
 
         // read configuration space
-        let config_space = transport.config_space::<Config>()?;
-        unsafe {
-            let events_read = volread!(config_space, events_read);
-            let num_scanouts = volread!(config_space, num_scanouts);
-            info!(
-                "events_read: {:#x}, num_scanouts: {:#x}",
-                events_read, num_scanouts
-            );
-        }
+        let events_read = transport.read_config_space::<u32>(offset_of!(Config, events_read));
+        let num_scanouts = transport.read_config_space::<u32>(offset_of!(Config, num_scanouts));
+        info!(
+            "events_read: {:#x}, num_scanouts: {:#x}",
+            events_read, num_scanouts
+        );
 
         let control_queue = VirtQueue::new(
             &mut transport,

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -44,8 +44,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
 
         // read configuration space
-        let events_read = transport.read_config_space::<u32>(offset_of!(Config, events_read));
-        let num_scanouts = transport.read_config_space::<u32>(offset_of!(Config, num_scanouts));
+        let events_read = transport.read_config_space::<u32>(offset_of!(Config, events_read))?;
+        let num_scanouts = transport.read_config_space::<u32>(offset_of!(Config, num_scanouts))?;
         info!(
             "events_read: {:#x}, num_scanouts: {:#x}",
             events_read, num_scanouts

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -4,12 +4,11 @@ use super::common::Feature;
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use crate::volatile::{volread, volwrite, ReadOnly, VolatileReadable, WriteOnly};
+use crate::volatile::{ReadOnly, WriteOnly};
 use crate::Error;
 use alloc::{boxed::Box, string::String};
 use core::cmp::min;
-use core::mem::size_of;
-use core::ptr::{addr_of, NonNull};
+use core::mem::{offset_of, size_of};
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 /// Virtual human interface devices such as keyboards, mice and tablets.
@@ -22,7 +21,6 @@ pub struct VirtIOInput<H: Hal, T: Transport> {
     event_queue: VirtQueue<H, QUEUE_SIZE>,
     status_queue: VirtQueue<H, QUEUE_SIZE>,
     event_buf: Box<[InputEvent; 32]>,
-    config: NonNull<Config>,
 }
 
 impl<H: Hal, T: Transport> VirtIOInput<H, T> {
@@ -31,8 +29,6 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);
 
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
-
-        let config = transport.config_space::<Config>()?;
 
         let mut event_queue = VirtQueue::new(
             &mut transport,
@@ -62,7 +58,6 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             event_queue,
             status_queue,
             event_buf,
-            config,
         })
     }
 
@@ -108,17 +103,19 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
         subsel: u8,
         out: &mut [u8],
     ) -> u8 {
-        let size;
+        self.transport
+            .write_config_space(offset_of!(Config, select), select as u8);
+        self.transport
+            .write_config_space(offset_of!(Config, subsel), subsel);
+        let size: u8 = self.transport.read_config_space(offset_of!(Config, size));
         // Safe because config points to a valid MMIO region for the config space.
-        unsafe {
-            volwrite!(self.config, select, select as u8);
-            volwrite!(self.config, subsel, subsel);
-            size = volread!(self.config, size);
-            let size_to_copy = min(usize::from(size), out.len());
-            for (i, out_item) in out.iter_mut().take(size_to_copy).enumerate() {
-                *out_item = addr_of!((*self.config.as_ptr()).data[i]).vread();
-            }
+        let size_to_copy = min(usize::from(size), out.len());
+        for (i, out_item) in out.iter_mut().take(size_to_copy).enumerate() {
+            *out_item = self
+                .transport
+                .read_config_space(offset_of!(Config, data) + i * size_of::<u8>());
         }
+
         size
     }
 
@@ -129,20 +126,24 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
         select: InputConfigSelect,
         subsel: u8,
     ) -> Result<Box<[u8]>, Error> {
-        // Safe because config points to a valid MMIO region for the config space.
-        unsafe {
-            volwrite!(self.config, select, select as u8);
-            volwrite!(self.config, subsel, subsel);
-            let size = usize::from(volread!(self.config, size));
-            if size > CONFIG_DATA_MAX_LENGTH {
-                return Err(Error::IoError);
-            }
-            let mut buf = <[u8]>::new_box_zeroed_with_elems(size).unwrap();
-            for i in 0..size {
-                buf[i] = addr_of!((*self.config.as_ptr()).data[i]).vread();
-            }
-            Ok(buf)
+        self.transport
+            .write_config_space(offset_of!(Config, select), select as u8);
+        self.transport
+            .write_config_space(offset_of!(Config, subsel), subsel);
+        let size = usize::from(
+            self.transport
+                .read_config_space::<u8>(offset_of!(Config, size)),
+        );
+        if size > CONFIG_DATA_MAX_LENGTH {
+            return Err(Error::IoError);
         }
+        let mut buf = <[u8]>::new_box_zeroed_with_elems(size).unwrap();
+        for i in 0..size {
+            buf[i] = self
+                .transport
+                .read_config_space(offset_of!(Config, data) + i * size_of::<u8>());
+        }
+        Ok(buf)
     }
 
     /// Queries a specific piece of information by `select` and `subsel` into a newly-allocated
@@ -322,7 +323,7 @@ mod tests {
         },
     };
     use alloc::{sync::Arc, vec};
-    use core::convert::TryInto;
+    use core::{convert::TryInto, ptr::NonNull};
     use std::sync::Mutex;
 
     #[test]

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -31,8 +31,8 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZ
         info!("negotiated_features {:?}", negotiated_features);
 
         // Read configuration space.
-        let mac = transport.read_config_space(offset_of!(Config, mac));
-        let status = transport.read_config_space::<Status>(offset_of!(Config, status));
+        let mac = transport.read_config_space(offset_of!(Config, mac))?;
+        let status = transport.read_config_space::<Status>(offset_of!(Config, status))?;
         debug!("Got MAC={:02x?}, status={:?}", mac, status);
 
         let send_queue = VirtQueue::new(

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -1,10 +1,11 @@
 use super::{Config, EthernetAddress, Features, VirtioNetHdr};
 use super::{MIN_BUFFER_LEN, NET_HDR_SIZE, QUEUE_RECEIVE, QUEUE_TRANSMIT, SUPPORTED_FEATURES};
+use crate::device::net::Status;
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
-use crate::volatile::volread;
 use crate::{Error, Result};
+use core::mem::offset_of;
 use log::{debug, info, warn};
 use zerocopy::IntoBytes;
 
@@ -28,18 +29,12 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZ
     pub fn new(mut transport: T) -> Result<Self> {
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
         info!("negotiated_features {:?}", negotiated_features);
-        // read configuration space
-        let config = transport.config_space::<Config>()?;
-        let mac;
-        // Safe because config points to a valid MMIO region for the config space.
-        unsafe {
-            mac = volread!(config, mac);
-            debug!(
-                "Got MAC={:02x?}, status={:?}",
-                mac,
-                volread!(config, status)
-            );
-        }
+
+        // Read configuration space.
+        let mac = transport.read_config_space(offset_of!(Config, mac));
+        let status = transport.read_config_space::<Status>(offset_of!(Config, status));
+        debug!("Got MAC={:02x?}, status={:?}", mac, status);
+
         let send_queue = VirtQueue::new(
             &mut transport,
             QUEUE_TRANSMIT,

--- a/src/device/net/mod.rs
+++ b/src/device/net/mod.rs
@@ -81,9 +81,12 @@ bitflags! {
     }
 }
 
+#[derive(Copy, Clone, Debug, Default, Eq, FromBytes, Immutable, KnownLayout, PartialEq)]
+#[repr(transparent)]
+struct Status(u16);
+
 bitflags! {
-    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-    struct Status: u16 {
+    impl Status: u16 {
         const LINK_UP = 1;
         const ANNOUNCE = 2;
     }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -248,11 +248,12 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
         let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
 
         // Safe because config is a valid pointer to the device configuration space.
-        let guest_cid =
-            transport.read_config_space::<u32>(offset_of!(VirtioVsockConfig, guest_cid_low)) as u64
-                | (transport.read_config_space::<u32>(offset_of!(VirtioVsockConfig, guest_cid_high))
-                    as u64)
-                    << 32;
+        let guest_cid = transport
+            .read_config_space::<u32>(offset_of!(VirtioVsockConfig, guest_cid_low))?
+            as u64
+            | (transport.read_config_space::<u32>(offset_of!(VirtioVsockConfig, guest_cid_high))?
+                as u64)
+                << 32;
         debug!("guest cid: {guest_cid:?}");
 
         let rx = VirtQueue::new(

--- a/src/device/sound.rs
+++ b/src/device/sound.rs
@@ -96,9 +96,9 @@ impl<H: Hal, T: Transport> VirtIOSound<H, T> {
         )?;
 
         // read configuration space
-        let jacks = transport.read_config_space(offset_of!(VirtIOSoundConfig, jacks));
-        let streams = transport.read_config_space(offset_of!(VirtIOSoundConfig, streams));
-        let chmaps = transport.read_config_space(offset_of!(VirtIOSoundConfig, chmaps));
+        let jacks = transport.read_config_space(offset_of!(VirtIOSoundConfig, jacks))?;
+        let streams = transport.read_config_space(offset_of!(VirtIOSoundConfig, streams))?;
+        let chmaps = transport.read_config_space(offset_of!(VirtIOSoundConfig, chmaps))?;
         info!(
             "[sound device] config: jacks: {}, streams: {}, chmaps: {}",
             jacks, streams, chmaps

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -1,7 +1,7 @@
 use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
     queue::{fake_read_write_queue, Descriptor},
-    PhysAddr,
+    Error, PhysAddr,
 };
 use alloc::{sync::Arc, vec::Vec};
 use core::{
@@ -96,23 +96,32 @@ impl<C> Transport for FakeTransport<C> {
         pending
     }
 
-    fn read_config_space<T>(&self, offset: usize) -> T {
+    fn read_config_space<T>(&self, offset: usize) -> Result<T, Error> {
         assert!(align_of::<T>() <= 4,
             "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
             align_of::<T>());
         assert!(offset % align_of::<T>() == 0);
-        assert!(offset + size_of::<T>() <= size_of::<C>());
-        unsafe { self.config_space.cast::<T>().byte_add(offset).read() }
+
+        if size_of::<C>() < offset + size_of::<T>() {
+            Err(Error::ConfigSpaceTooSmall)
+        } else {
+            unsafe { Ok(self.config_space.cast::<T>().byte_add(offset).read()) }
+        }
     }
 
-    fn write_config_space<T>(&mut self, offset: usize, value: T) {
+    fn write_config_space<T>(&mut self, offset: usize, value: T) -> Result<(), Error> {
         assert!(align_of::<T>() <= 4,
             "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
             align_of::<T>());
         assert!(offset % align_of::<T>() == 0);
-        assert!(offset + size_of::<T>() <= size_of::<C>());
-        unsafe {
-            self.config_space.cast::<T>().byte_add(offset).write(value);
+
+        if size_of::<C>() < offset + size_of::<T>() {
+            Err(Error::ConfigSpaceTooSmall)
+        } else {
+            unsafe {
+                self.config_space.cast::<T>().byte_add(offset).write(value);
+            }
+            Ok(())
         }
     }
 }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -5,7 +5,7 @@ use crate::{
     align_up,
     queue::Descriptor,
     volatile::{volread, volwrite, ReadOnly, Volatile, WriteOnly},
-    Error, PhysAddr, PAGE_SIZE,
+    PhysAddr, PAGE_SIZE,
 };
 use core::{
     convert::{TryFrom, TryInto},
@@ -484,15 +484,36 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn config_space<T>(&self) -> Result<NonNull<T>, Error> {
-        if align_of::<T>() > 4 {
-            // Panic as this should only happen if the driver is written incorrectly.
-            panic!(
-                "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
-                align_of::<T>()
-            );
+    fn read_config_space<T>(&self, offset: usize) -> T {
+        assert!(align_of::<T>() <= 4,
+            "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+            align_of::<T>());
+        assert!(offset % align_of::<T>() == 0);
+        // SAFETY: The caller of `MmioTransport::new` guaranteed that the header pointer was valid,
+        // which includes the config space.
+        unsafe {
+            self.header
+                .cast::<T>()
+                .byte_add(CONFIG_SPACE_OFFSET)
+                .byte_add(offset)
+                .read_volatile()
         }
-        Ok(NonNull::new((self.header.as_ptr() as usize + CONFIG_SPACE_OFFSET) as _).unwrap())
+    }
+
+    fn write_config_space<T>(&mut self, offset: usize, value: T) {
+        assert!(align_of::<T>() <= 4,
+            "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+            align_of::<T>());
+        assert!(offset % align_of::<T>() == 0);
+        // SAFETY: The caller of `MmioTransport::new` guaranteed that the header pointer was valid,
+        // which includes the config space.
+        unsafe {
+            self.header
+                .cast::<T>()
+                .byte_add(CONFIG_SPACE_OFFSET)
+                .byte_add(offset)
+                .write_volatile(value);
+        }
     }
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,10 +5,11 @@ pub mod fake;
 pub mod mmio;
 pub mod pci;
 
-use crate::{PhysAddr, Result, PAGE_SIZE};
+use crate::{PhysAddr, PAGE_SIZE};
 use bitflags::{bitflags, Flags};
-use core::{fmt::Debug, ops::BitAnd, ptr::NonNull};
+use core::{fmt::Debug, ops::BitAnd};
 use log::debug;
+use zerocopy::{FromBytes, IntoBytes};
 
 /// A VirtIO transport layer.
 pub trait Transport {
@@ -98,8 +99,11 @@ pub trait Transport {
         );
     }
 
-    /// Gets the pointer to the config space.
-    fn config_space<T: 'static>(&self) -> Result<NonNull<T>>;
+    /// Reads a value from the device config space.
+    fn read_config_space<T: FromBytes>(&self, offset: usize) -> T;
+
+    /// Writes a value to the device config space.
+    fn write_config_space<T: IntoBytes>(&mut self, offset: usize, value: T);
 }
 
 bitflags! {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,7 +5,7 @@ pub mod fake;
 pub mod mmio;
 pub mod pci;
 
-use crate::{PhysAddr, PAGE_SIZE};
+use crate::{PhysAddr, Result, PAGE_SIZE};
 use bitflags::{bitflags, Flags};
 use core::{fmt::Debug, ops::BitAnd};
 use log::debug;
@@ -100,10 +100,10 @@ pub trait Transport {
     }
 
     /// Reads a value from the device config space.
-    fn read_config_space<T: FromBytes>(&self, offset: usize) -> T;
+    fn read_config_space<T: FromBytes>(&self, offset: usize) -> Result<T>;
 
     /// Writes a value to the device config space.
-    fn write_config_space<T: IntoBytes>(&mut self, offset: usize, value: T);
+    fn write_config_space<T: IntoBytes>(&mut self, offset: usize, value: T) -> Result<()>;
 }
 
 bitflags! {

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -12,7 +12,6 @@ use crate::{
     volatile::{
         volread, volwrite, ReadOnly, Volatile, VolatileReadable, VolatileWritable, WriteOnly,
     },
-    Error,
 };
 use core::{
     mem::{align_of, size_of},
@@ -325,23 +324,41 @@ impl Transport for PciTransport {
         isr_status & 0x3 != 0
     }
 
-    fn config_space<T>(&self) -> Result<NonNull<T>, Error> {
-        if let Some(config_space) = self.config_space {
-            if size_of::<T>() > config_space.len() * size_of::<u32>() {
-                Err(Error::ConfigSpaceTooSmall)
-            } else if align_of::<T>() > 4 {
-                // Panic as this should only happen if the driver is written incorrectly.
-                panic!(
-                    "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
-                    align_of::<T>()
-                );
-            } else {
-                // TODO: Use NonNull::as_non_null_ptr once it is stable.
-                let config_space_ptr = NonNull::new(config_space.as_ptr() as *mut u32).unwrap();
-                Ok(config_space_ptr.cast())
-            }
-        } else {
-            Err(Error::ConfigSpaceMissing)
+    fn read_config_space<T>(&self, offset: usize) -> T {
+        assert!(align_of::<T>() <= 4,
+            "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+            align_of::<T>());
+        assert_eq!(offset % align_of::<T>(), 0);
+
+        let config_space: NonNull<[u32]> = self.config_space.unwrap();
+        assert!(offset + size_of::<T>() <= config_space.len() * size_of::<u32>());
+
+        // SAFETY: If we have a config space pointer it must be valid for its length, and we just
+        // checked that the offset and size of the access was within the length.
+        unsafe {
+            // TODO: Use NonNull::as_non_null_ptr once it is stable.
+            (config_space.as_ptr() as *mut T)
+                .byte_add(offset)
+                .read_volatile()
+        }
+    }
+
+    fn write_config_space<T>(&mut self, offset: usize, value: T) {
+        assert!(align_of::<T>() <= 4,
+            "Driver expected config space alignment of {} bytes, but VirtIO only guarantees 4 byte alignment.",
+            align_of::<T>());
+        assert_eq!(offset % align_of::<T>(), 0);
+
+        let config_space = self.config_space.unwrap();
+        assert!(offset + size_of::<T>() <= config_space.len() * size_of::<u32>());
+
+        // SAFETY: If we have a config space pointer it must be valid for its length, and we just
+        // checked that the offset and size of the access was within the length.
+        unsafe {
+            // TODO: Use NonNull::as_non_null_ptr once it is stable.
+            (config_space.as_ptr() as *mut T)
+                .byte_add(offset)
+                .write_volatile(value);
         }
     }
 }


### PR DESCRIPTION
The config space is not necessarily memory mapped, some other transports require the config space to be accessed via other IO operations such as hypercalls.