### PR TITLE
Use thiserror for error types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.22"
 bitflags = "2.6.0"
 enumn = "0.1.14"
 embedded-io = { version = "0.6.1", optional = true }
+thiserror = { version = "2.0.0", default-features = false }
 zerocopy = { version = "0.8.7", features = ["derive"] }
 
 [features]

--- a/src/device/socket/error.rs
+++ b/src/device/socket/error.rs
@@ -1,61 +1,47 @@
 //! This module contain the error from the VirtIO socket driver.
 
-use core::{fmt, result};
+use core::result;
+use thiserror::Error;
 
 /// The error type of VirtIO socket driver.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum SocketError {
     /// There is an existing connection.
+    #[error("There is an existing connection. Please close the current connection before attempting to connect again.")]
     ConnectionExists,
     /// The device is not connected to any peer.
+    #[error("The device is not connected to any peer. Please connect it to a peer first.")]
     NotConnected,
     /// Peer socket is shutdown.
+    #[error("The peer socket is shutdown.")]
     PeerSocketShutdown,
     /// The given buffer is shorter than expected.
+    #[error("The given buffer is shorter than expected")]
     BufferTooShort,
     /// The given buffer for output is shorter than expected.
+    #[error("The given output buffer is too short. '{0}' bytes is needed for the output buffer.")]
     OutputBufferTooShort(usize),
     /// The given buffer has exceeded the maximum buffer size.
+    #[error("The given buffer length '{0}' has exceeded the maximum allowed buffer length '{1}'")]
     BufferTooLong(usize, usize),
     /// Unknown operation.
+    #[error("The operation code '{0}' is unknown")]
     UnknownOperation(u16),
     /// Invalid operation,
+    #[error("Invalid operation")]
     InvalidOperation,
     /// Invalid number.
+    #[error("Invalid number")]
     InvalidNumber,
     /// Unexpected data in packet.
+    #[error("No data is expected in the packet")]
     UnexpectedDataInPacket,
     /// Peer has insufficient buffer space, try again later.
+    #[error("Peer has insufficient buffer space, try again later")]
     InsufficientBufferSpaceInPeer,
     /// Recycled a wrong buffer.
+    #[error("Recycled a wrong buffer")]
     RecycledWrongBuffer,
-}
-
-impl fmt::Display for SocketError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::ConnectionExists => write!(
-                f,
-                "There is an existing connection. Please close the current connection before attempting to connect again."),
-            Self::NotConnected => write!(f, "The device is not connected to any peer. Please connect it to a peer first."),
-            Self::PeerSocketShutdown => write!(f, "The peer socket is shutdown."),
-            Self::BufferTooShort => write!(f, "The given buffer is shorter than expected"),
-            Self::BufferTooLong(actual, max) => {
-                write!(f, "The given buffer length '{actual}' has exceeded the maximum allowed buffer length '{max}'")
-            }
-            Self::OutputBufferTooShort(expected) => {
-                write!(f, "The given output buffer is too short. '{expected}' bytes is needed for the output buffer.")
-            }
-            Self::UnknownOperation(op) => {
-                write!(f, "The operation code '{op}' is unknown")
-            }
-            Self::InvalidOperation => write!(f, "Invalid operation"),
-            Self::InvalidNumber => write!(f, "Invalid number"),
-            Self::UnexpectedDataInPacket => write!(f, "No data is expected in the packet"),
-            Self::InsufficientBufferSpaceInPeer => write!(f, "Peer has insufficient buffer space, try again later"),
-            Self::RecycledWrongBuffer => write!(f, "Recycled a wrong buffer"),
-        }
-    }
 }
 
 pub type Result<T> = result::Result<T, SocketError>;

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use core::{
     convert::{TryFrom, TryInto},
-    fmt::{self, Display, Formatter},
     mem::{align_of, size_of},
     ptr::NonNull,
 };
@@ -51,30 +50,17 @@ impl From<MmioVersion> for u32 {
 }
 
 /// An error encountered initialising a VirtIO MMIO transport.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum MmioError {
     /// The header doesn't start with the expected magic value 0x74726976.
+    #[error("Invalid magic value {0:#010x} (expected 0x74726976)")]
     BadMagic(u32),
     /// The header reports a version number that is neither 1 (legacy) nor 2 (modern).
+    #[error("Unsupported Virtio MMIO version {0}")]
     UnsupportedVersion(u32),
     /// The header reports a device ID of 0.
+    #[error("Device ID was zero")]
     ZeroDeviceId,
-}
-
-impl Display for MmioError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::BadMagic(magic) => write!(
-                f,
-                "Invalid magic value {:#010x} (expected 0x74726976).",
-                magic
-            ),
-            Self::UnsupportedVersion(version) => {
-                write!(f, "Unsupported Virtio MMIO version {}.", version)
-            }
-            Self::ZeroDeviceId => write!(f, "Device ID was zero."),
-        }
-    }
 }
 
 /// MMIO Device Register Interface, both legacy and modern.

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -7,6 +7,7 @@ use core::{
     fmt::{self, Display, Formatter},
 };
 use log::warn;
+use thiserror::Error;
 
 const INVALID_READ: u32 = 0xffffffff;
 
@@ -82,18 +83,11 @@ bitflags! {
 }
 
 /// Errors accessing a PCI device.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum PciError {
     /// The device reported an invalid BAR type.
+    #[error("Invalid PCI BAR type")]
     InvalidBarType,
-}
-
-impl Display for PciError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidBarType => write!(f, "Invalid PCI BAR type."),
-        }
-    }
 }
 
 /// The root complex of a PCI bus.


### PR DESCRIPTION
This reduces boilerplate, and adds a core::error::Error implementation.