### PR TITLE
add macro to read config fields

### DIFF
--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -1,5 +1,5 @@
 /// An MMIO register which can only be read from.
-#[derive(Default)]
+#[derive(Default, zerocopy::FromBytes)]
 #[repr(transparent)]
 pub struct ReadOnly<T: Copy>(pub(crate) T);
 
@@ -11,12 +11,12 @@ impl<T: Copy> ReadOnly<T> {
 }
 
 /// An MMIO register which can only be written to.
-#[derive(Default)]
+#[derive(Default, zerocopy::FromBytes)]
 #[repr(transparent)]
 pub struct WriteOnly<T: Copy>(pub(crate) T);
 
 /// An MMIO register which may be both read and written.
-#[derive(Default)]
+#[derive(Default, zerocopy::FromBytes)]
 #[repr(transparent)]
 pub struct Volatile<T: Copy>(T);
 


### PR DESCRIPTION
Ensures that the offset and type match.

Proof of concept of https://github.com/rcore-os/virtio-drivers/pull/163#discussion_r1859185821

This doesn't mesh well with the existing config struct definitions, which use
types to specify qualities like "read only" and "volatile". Since
https://github.com/rcore-os/virtio-drivers/pull/163, it seems like those are
essentially ignored, so, if this macro seems like a good idea, it would
probably make sense to change the config types to be plain-old-data struct that
implement zerocopy traits.
