### PR TITLE
Use &raw rather than addr_of macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ fn align_up(size: usize) -> usize {
 
 /// The number of pages required to store `size` bytes, rounded up to a whole number of pages.
 fn pages(size: usize) -> usize {
-    (size + PAGE_SIZE - 1) / PAGE_SIZE
+    size.div_ceil(PAGE_SIZE)
 }
 
 // TODO: Use NonNull::slice_from_raw_parts once it is stable.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -811,7 +811,7 @@ impl<'a, 'b> InputOutputIter<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Iterator for InputOutputIter<'a, 'b> {
+impl Iterator for InputOutputIter<'_, '_> {
     type Item = (NonNull<[u8]>, BufferDirection);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -1,3 +1,5 @@
+//! A fake implementation of `Transport` for unit tests.
+
 use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
     queue::{fake_read_write_queue, Descriptor},
@@ -173,6 +175,7 @@ impl<C> Debug for State<C> {
 }
 
 impl<C> State<C> {
+    /// Creates a state for a fake transport, with the given queues and VirtIO configuration space.
     pub const fn new(queues: Vec<QueueStatus>, config_space: C) -> Self {
         Self {
             status: DeviceStatus::empty(),
@@ -266,11 +269,17 @@ impl<C> State<C> {
     }
 }
 
+/// The status of a fake virtqueue.
 #[derive(Debug, Default)]
 pub struct QueueStatus {
+    /// The size of the fake virtqueue.
     pub size: u32,
+    /// The physical address set for the queue's descriptors.
     pub descriptors: PhysAddr,
+    /// The physical address set for the queue's driver area.
     pub driver_area: PhysAddr,
+    /// The physical address set for the queue's device area.
     pub device_area: PhysAddr,
+    /// Whether the queue has been notified by the driver since last we checked.
     pub notified: AtomicBool,
 }

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use core::{
     mem::{align_of, size_of},
-    ptr::{addr_of_mut, NonNull},
+    ptr::NonNull,
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -256,7 +256,7 @@ impl Transport for PciTransport {
 
             let offset_bytes = usize::from(queue_notify_off) * self.notify_off_multiplier as usize;
             let index = offset_bytes / size_of::<u16>();
-            addr_of_mut!((*self.notify_region.as_ptr())[index]).vwrite(queue);
+            (&raw mut (*self.notify_region.as_ptr())[index]).vwrite(queue);
         }
     }
 

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -486,7 +486,7 @@ pub struct CapabilityIterator<'a, C: ConfigurationAccess> {
     next_capability_offset: Option<u8>,
 }
 
-impl<'a, C: ConfigurationAccess> Iterator for CapabilityIterator<'a, C> {
+impl<C: ConfigurationAccess> Iterator for CapabilityIterator<'_, C> {
     type Item = CapabilityInfo;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -78,7 +78,7 @@ impl<T: Copy> VolatileWritable<T> for *mut Volatile<T> {
 /// ```
 macro_rules! volread {
     ($nonnull:expr, $field:ident) => {
-        $crate::volatile::VolatileReadable::vread(core::ptr::addr_of!((*$nonnull.as_ptr()).$field))
+        $crate::volatile::VolatileReadable::vread((&raw const (*$nonnull.as_ptr()).$field))
     };
 }
 
@@ -97,10 +97,7 @@ macro_rules! volread {
 /// ```
 macro_rules! volwrite {
     ($nonnull:expr, $field:ident, $value:expr) => {
-        $crate::volatile::VolatileWritable::vwrite(
-            core::ptr::addr_of_mut!((*$nonnull.as_ptr()).$field),
-            $value,
-        )
+        $crate::volatile::VolatileWritable::vwrite((&raw mut (*$nonnull.as_ptr()).$field), $value)
     };
 }
 


### PR DESCRIPTION
Also added Rustdoc comments for fake transport, as it was breaking the build. Not sure why this wasn't an issue before.