### PR TITLE
PCI: read full 64-bit size of 64-bit memory BARs

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -418,6 +418,13 @@ fn allocate_bars(
             address_type, size, ..
         } = info
         {
+            // For now, only attempt to allocate 32-bit memory regions.
+            if size > u32::MAX.into() {
+                warn!("Skipping BAR {} with size {:#x}", bar_index, size);
+                continue;
+            }
+            let size = size as u32;
+
             match address_type {
                 MemoryBarType::Width32 => {
                     if size > 0 {

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -436,7 +436,7 @@ fn get_bar_region<H: Hal, T, C: ConfigurationAccess>(
     if bar_address == 0 {
         return Err(VirtioPciError::BarNotAllocated(struct_info.bar));
     }
-    if struct_info.offset + struct_info.length > bar_size
+    if u64::from(struct_info.offset + struct_info.length) > bar_size
         || size_of::<T>() > struct_info.length as usize
     {
         return Err(VirtioPciError::BarOffsetOutOfRange);

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -295,7 +295,7 @@ fn get_bar_region<T, C: ConfigurationAccess>(
     if bar_address == 0 {
         return Err(VirtioPciError::BarNotAllocated(struct_info.bar));
     }
-    if struct_info.offset + struct_info.length > bar_size
+    if u64::from(struct_info.offset + struct_info.length) > bar_size
         || size_of::<T>() > struct_info.length as usize
     {
         return Err(VirtioPciError::BarOffsetOutOfRange);


### PR DESCRIPTION
64-bit memory BARs not only have a 64-bit-wide address, but also a 64-bit-wide size. Change the bar_info() function to retrieve the upper 32 bits of the size and include it in the size calculation.

This modifies the return type of the BarInfo::memory_address_size() function, so callers may need to modify their code to adapt to the new 64-bit size.

Fixes GitHub issue #177.