### PR TITLE
Add remaining safety comments

### DIFF
--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -115,12 +115,13 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // map frame buffer to screen
         self.set_scanout(display_info.rect, SCANOUT_ID, RESOURCE_ID_FB)?;
 
-        // SAFETY: The pointer returned from `raw_slice` is guaranteed to be
-        // non-null, aligned, and a valid allocation. We store the `Dma` object
-        // in `self.frame_buffer_dma`, which prevents the allocation from being
-        // freed while `self` exists. The returned ptr borrows `self` mutably,
-        // which prevents other code from getting another reference to
-        // `frame_buffer_dma` while the returned slice is still in use.
+        // SAFETY: `Dma::new` guarantees that the pointer returned from
+        // `raw_slice` is non-null, aligned, and the allocation is zeroed. We
+        // store the `Dma` object in `self.frame_buffer_dma`, which prevents the
+        // allocation from being freed while `self` exists. The returned ptr
+        // borrows `self` mutably, which prevents other code from getting
+        // another reference to `frame_buffer_dma` while the returned slice is
+        // still in use.
         let buf = unsafe { frame_buffer_dma.raw_slice().as_mut() };
         self.frame_buffer_dma = Some(frame_buffer_dma);
         Ok(buf)
@@ -150,6 +151,11 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             return Err(Error::InvalidParam);
         }
         let cursor_buffer_dma = Dma::new(pages(size as usize), BufferDirection::DriverToDevice)?;
+
+        // SAFETY: `Dma::new` guarantees that the pointer returned from
+        // `raw_slice` is non-null, aligned, and the allocation is zeroed. The
+        // returned reference is only used within this function while
+        // `cursor_buffer_dma` is alive.
         let buf = unsafe { cursor_buffer_dma.raw_slice().as_mut() };
         buf.copy_from_slice(cursor_image);
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -115,6 +115,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // map frame buffer to screen
         self.set_scanout(display_info.rect, SCANOUT_ID, RESOURCE_ID_FB)?;
 
+        // SAFETY: The pointer returned from `raw_slice` is guaranteed to be
+        // non-null, aligned, and a valid allocation. We store the `Dma` object
+        // in `self.frame_buffer_dma`, which prevents the allocation from being
+        // freed while `self` exists. The returned ptr borrows `self` mutably,
+        // which prevents other code from getting another reference to
+        // `frame_buffer_dma` while the returned slice is still in use.
         let buf = unsafe { frame_buffer_dma.raw_slice().as_mut() };
         self.frame_buffer_dma = Some(frame_buffer_dma);
         Ok(buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
-#![deny(unused_must_use, missing_docs)]
+#![deny(unused_must_use, missing_docs, clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::identity_op)]
 #![allow(dead_code)]
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -280,7 +280,9 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         self.free_head = direct_desc.next;
 
         // SAFETY: Using `Box::leak` on `indirect_list` guarantees it won't be deallocated
-        // while in use.
+        // when this function returns. The allocation isn't freed until
+        // `recycle_descriptors` is called, at which point the allocation is no longer being
+        // used.
         unsafe {
             direct_desc.set_buf::<H>(
                 Box::leak(indirect_list).as_bytes().into(),
@@ -436,6 +438,10 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
                 self.num_used -= 1;
                 head_desc.next = original_free_head;
 
+                // SAFETY: `paddr` comes from a previous call `H::share` (inside
+                // `Descriptor::set_buf`, which was called from `add_direct` or `add_indirect`).
+                // `indirect_list` is owned by this function and is not accessed from any other
+                // threads.
                 unsafe {
                     H::unshare(
                         paddr as usize,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -440,8 +440,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
 
                 // SAFETY: `paddr` comes from a previous call `H::share` (inside
                 // `Descriptor::set_buf`, which was called from `add_direct` or `add_indirect`).
-                // `indirect_list` is owned by this function and is not accessed from any other
-                // threads.
+                // `indirect_list` is owned by this function and is not accessed from any other threads.
                 unsafe {
                     H::unshare(
                         paddr as usize,
@@ -540,6 +539,8 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         self.last_used_idx = self.last_used_idx.wrapping_add(1);
 
         if self.event_idx {
+            // SAFETY: `self.avail` points to a valid, aligned, initialised, dereferenceable,
+            // readable instance of `AvailRing`.
             unsafe {
                 (*self.avail.as_ptr())
                     .used_event

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -278,6 +278,9 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         // responsible for freeing the memory after the buffer chain is popped.
         let direct_desc = &mut self.desc_shadow[usize::from(head)];
         self.free_head = direct_desc.next;
+
+        // SAFETY: Using `Box::leak` on `indirect_list` guarantees it won't be deallocated
+        // while in use.
         unsafe {
             direct_desc.set_buf::<H>(
                 Box::leak(indirect_list).as_bytes().into(),


### PR DESCRIPTION
Add `SAFETY` comments to the remaining undocumented `unsafe` blocks. I did my best to accurately cover why each block is unsafe, but I'm not familiar with virtio and may have missed some subtle details. Let me know if anything needs adjustment.