### PR TITLE
Add VirtIORng driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ VirtIO guest drivers in Rust. For **no_std** environment.
 | Console | ✅        |
 | Socket  | ✅        |
 | Sound   | ✅        |
+| RNG     | ✅        |
 | ...     | ❌        |
 
 ### Transports

--- a/examples/aarch64/Makefile
+++ b/examples/aarch64/Makefile
@@ -84,6 +84,7 @@ qemu: $(kernel_qemu_bin) $(img) $(vsock_server_bin)
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device vhost-vsock-device,id=virtiosocket0,guest-cid=102 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-serial,id=virtio-serial0 \
 		-chardev stdio,id=char0,mux=on \
@@ -101,6 +102,7 @@ qemu-pci: $(kernel_qemu_bin) $(img)
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device vhost-vsock-pci,id=virtiosocket0,guest-cid=103 \
 		-device virtio-blk-pci,drive=x0 \
+		-device virtio-rng-pci \
 		-device virtio-gpu-pci \
 		-device virtio-serial,id=virtio-serial0 \
 		-chardev stdio,id=char0,mux=on \

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -38,6 +38,7 @@ use virtio_drivers::{
         console::VirtIOConsole,
         gpu::VirtIOGpu,
         net::VirtIONetRaw,
+        rng::VirtIORng,
         socket::{
             VirtIOSocket, VsockAddr, VsockConnectionManager, VsockEventType, VMADDR_CID_HOST,
         },
@@ -212,8 +213,19 @@ fn virtio_device(transport: impl Transport) {
             Ok(()) => info!("virtio-socket test finished successfully"),
             Err(e) => error!("virtio-socket test finished with error '{e:?}'"),
         },
+        DeviceType::EntropySource => virtio_rng(transport),
         t => warn!("Unrecognized virtio device: {:?}", t),
     }
+}
+
+fn virtio_rng<T: Transport>(transport: T) {
+    let mut bytes = [0u8; 8];
+    let mut rng = VirtIORng::<HalImpl, T>::new(transport).expect("failed to create rng driver");
+    let len = rng
+        .request_entropy(&mut bytes)
+        .expect("failed to receive entropy");
+    info!("received {len} random bytes: {:?}", &bytes[..len]);
+    info!("virtio-rng test finished");
 }
 
 fn virtio_blk<T: Transport>(transport: T) {

--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -55,6 +55,7 @@ qemu-legacy: kernel $(img)
 		-kernel $(kernel) \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-mouse-device \
 		-device virtio-net-device,netdev=net0 \
@@ -74,6 +75,7 @@ qemu: kernel $(img)
 		-global virtio-mmio.force-legacy=false \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-mouse-device \
 		-device virtio-net-device,netdev=net0 \

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -17,6 +17,7 @@ use virtio_drivers::{
         blk::VirtIOBlk,
         gpu::VirtIOGpu,
         input::VirtIOInput,
+        rng::VirtIORng,
         sound::{PcmFormat, PcmRate, VirtIOSound},
     },
     transport::{
@@ -91,8 +92,19 @@ fn virtio_device(transport: impl Transport) {
         DeviceType::Input => virtio_input(transport),
         DeviceType::Network => virtio_net(transport),
         DeviceType::Sound => virtio_sound(transport),
+        DeviceType::EntropySource => virtio_rng(transport),
         t => warn!("Unrecognized virtio device: {:?}", t),
     }
+}
+
+fn virtio_rng<T: Transport>(transport: T) {
+    let mut bytes = [0u8; 8];
+    let mut rng = VirtIORng::<HalImpl, T>::new(transport).expect("failed to create rng driver");
+    let len = rng
+        .request_entropy(&mut bytes)
+        .expect("failed to receive entropy");
+    info!("received {len} random bytes: {:?}", &bytes[..len]);
+    info!("virtio-rng test finished");
 }
 
 fn virtio_blk<T: Transport>(transport: T) {

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -26,6 +26,7 @@ QEMU_ARGS += \
 	-kernel $(kernel) \
 	-device virtio-gpu-pci -vga none \
 	-device virtio-blk-pci,drive=x0 -drive file=$(img),if=none,format=raw,id=x0 \
+	-device virtio-rng-pci \
 	-device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::5555-:5555
 
 ifeq ($(accel), on)

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -18,7 +18,7 @@ mod tcp;
 
 use self::hal::HalImpl;
 use virtio_drivers::{
-    device::{blk::VirtIOBlk, gpu::VirtIOGpu},
+    device::{blk::VirtIOBlk, gpu::VirtIOGpu, rng::VirtIORng},
     transport::{
         pci::{
             bus::{BarInfo, Cam, Command, ConfigurationAccess, DeviceFunction, MmioCam, PciRoot},
@@ -66,8 +66,19 @@ fn virtio_device(transport: impl Transport) {
         DeviceType::Block => virtio_blk(transport),
         DeviceType::GPU => virtio_gpu(transport),
         DeviceType::Network => virtio_net(transport),
+        DeviceType::EntropySource => virtio_rng(transport),
         t => warn!("Unrecognized virtio device: {:?}", t),
     }
+}
+
+fn virtio_rng<T: Transport>(transport: T) {
+    let mut bytes = [0u8; 8];
+    let mut rng = VirtIORng::<HalImpl, T>::new(transport).expect("failed to create rng driver");
+    let len = rng
+        .request_entropy(&mut bytes)
+        .expect("failed to receive entropy");
+    info!("received {len} random bytes: {:?}", &bytes[..len]);
+    info!("virtio-rng test finished");
 }
 
 fn virtio_blk<T: Transport>(transport: T) {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -10,6 +10,8 @@ pub mod input;
 
 pub mod net;
 
+pub mod rng;
+
 pub mod socket;
 #[cfg(feature = "alloc")]
 pub mod sound;

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,0 +1,58 @@
+//! Driver for VirtIO random number generator devices.
+use super::common::Feature;
+use crate::{queue::VirtQueue, transport::Transport, Hal, Result};
+
+// VirtioRNG only uses one queue
+const QUEUE_IDX: u16 = 0;
+const QUEUE_SIZE: usize = 8;
+const SUPPORTED_FEATURES: Feature = Feature::RING_INDIRECT_DESC.union(Feature::RING_EVENT_IDX);
+
+/// Driver for a VirtIO random number generator device.
+pub struct VirtIORng<H: Hal, T: Transport> {
+    transport: T,
+    queue: VirtQueue<H, QUEUE_SIZE>,
+}
+
+impl<H: Hal, T: Transport> VirtIORng<H, T> {
+    /// Create a new driver with the given transport.
+    pub fn new(mut transport: T) -> Result<Self> {
+        let feat = transport.begin_init(SUPPORTED_FEATURES);
+        let queue = VirtQueue::new(
+            &mut transport,
+            QUEUE_IDX,
+            feat.contains(Feature::RING_INDIRECT_DESC),
+            feat.contains(Feature::RING_EVENT_IDX),
+        )?;
+        transport.finish_init();
+        Ok(Self { transport, queue })
+    }
+
+    /// Request random bytes from the device to be stored into `dst`.
+    pub fn request_entropy(&mut self, dst: &mut [u8]) -> Result<usize> {
+        let num = self
+            .queue
+            .add_notify_wait_pop(&[], &mut [dst], &mut self.transport)?;
+        Ok(num as usize)
+    }
+
+    /// Enable interrupts.
+    pub fn enable_interrupts(&mut self) {
+        self.queue.set_dev_notify(true);
+    }
+
+    /// Disable interrupts.
+    pub fn disable_interrupts(&mut self) {
+        self.queue.set_dev_notify(false);
+    }
+
+    /// Acknowledge interrupt.
+    pub fn ack_interrupt(&mut self) -> bool {
+        self.transport.ack_interrupt()
+    }
+}
+
+impl<H: Hal, T: Transport> Drop for VirtIORng<H, T> {
+    fn drop(&mut self) {
+        self.transport.queue_unset(QUEUE_IDX);
+    }
+}


### PR DESCRIPTION
Add a driver for the entropy source device, also known as virtio-rng in qemu. Add basic usage as well in the repo examples for all architectures.