### PR TITLE
Return None rather than size 0 for unused BARs

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -471,7 +471,7 @@ fn dump_bar_contents(
 ) {
     let bar_info = root.bar_info(device_function, bar_index).unwrap();
     trace!("Dumping bar {}: {:#x?}", bar_index, bar_info);
-    if let BarInfo::Memory { address, size, .. } = bar_info {
+    if let Some(BarInfo::Memory { address, size, .. }) = bar_info {
         let start = address as *const u8;
         unsafe {
             let mut buf = [0u8; 32];

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -197,7 +197,7 @@ fn dump_bar_contents(
 ) {
     let bar_info = root.bar_info(device_function, bar_index).unwrap();
     trace!("Dumping bar {}: {:#x?}", bar_index, bar_info);
-    if let BarInfo::Memory { address, size, .. } = bar_info {
+    if let Some(BarInfo::Memory { address, size, .. }) = bar_info {
         let start = address as *const u8;
         unsafe {
             let mut buf = [0u8; 32];

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -418,7 +418,9 @@ fn get_bar_region<H: Hal, T, C: ConfigurationAccess>(
     device_function: DeviceFunction,
     struct_info: &VirtioCapabilityInfo,
 ) -> Result<NonNull<T>, VirtioPciError> {
-    let bar_info = root.bar_info(device_function, struct_info.bar)?;
+    let bar_info = root
+        .bar_info(device_function, struct_info.bar)?
+        .ok_or_else(|| VirtioPciError::BarNotAllocated(struct_info.bar))?;
     let (bar_address, bar_size) = bar_info
         .memory_address_size()
         .ok_or(VirtioPciError::UnexpectedIoBar)?;

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -713,7 +713,7 @@ mod tests {
         };
         let fake_cam = FakeCam {
             device_function,
-            bar_values: [0, 0, 0, 0, 0, 0],
+            bar_values: [0, 1, 4, 0, 0, 0],
             bar_masks: [
                 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
             ],
@@ -730,24 +730,17 @@ mod tests {
                     address: 0,
                     size: 0,
                 }),
-                Some(BarInfo::Memory {
-                    address_type: MemoryBarType::Width32,
-                    prefetchable: false,
+                Some(BarInfo::IO {
                     address: 0,
                     size: 0,
                 }),
                 Some(BarInfo::Memory {
-                    address_type: MemoryBarType::Width32,
+                    address_type: MemoryBarType::Width64,
                     prefetchable: false,
                     address: 0,
                     size: 0,
                 }),
-                Some(BarInfo::Memory {
-                    address_type: MemoryBarType::Width32,
-                    prefetchable: false,
-                    address: 0,
-                    size: 0,
-                }),
+                None,
                 Some(BarInfo::Memory {
                     address_type: MemoryBarType::Width32,
                     prefetchable: false,

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -289,7 +289,9 @@ fn get_bar_region<T, C: ConfigurationAccess>(
     device_function: DeviceFunction,
     struct_info: &VirtioCapabilityInfo,
 ) -> Result<HypIoRegion, VirtioPciError> {
-    let bar_info = root.bar_info(device_function, struct_info.bar)?;
+    let bar_info = root
+        .bar_info(device_function, struct_info.bar)?
+        .ok_or_else(|| VirtioPciError::BarNotAllocated(struct_info.bar))?;
     let (bar_address, bar_size) = bar_info
         .memory_address_size()
         .ok_or(VirtioPciError::UnexpectedIoBar)?;


### PR DESCRIPTION
This changes the return type of `PciRoot::bar_info`, so is a breaking change.