### PR TITLE
Reduce timeout for running examples.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,6 @@ jobs:
         working-directory: examples/${{ matrix.example }}
         run: make kernel
       - name: Run
+        timeout-minutes: 1
         working-directory: examples/${{ matrix.example }}
         run: QEMU_ARGS="-display none -audiodev none,id=audio0" make qemu accel="off"


### PR DESCRIPTION
If they don't finish after a minute they are going to hang forever.