### PR TITLE
Derive Ord for DeviceType

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -177,7 +177,7 @@ bitflags! {
 
 /// Types of virtio devices.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[allow(missing_docs)]
 pub enum DeviceType {
     Network = 1,


### PR DESCRIPTION
This allows the type to be used in BTreeSet/BTreeMap from `alloc`. We cannot use HashMap/HashSet because they require `std`.