### PR TITLE
Make `ack_interrupt` return interrupt status

### DIFF
--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -3,7 +3,7 @@
 use crate::config::{read_config, ReadOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result};
 use bitflags::bitflags;
 use log::info;
@@ -90,7 +90,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// Acknowledges a pending interrupt, if any.
     ///
     /// Returns true if there was an interrupt to acknowledge.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -6,7 +6,7 @@ mod embedded_io;
 use crate::config::{read_config, write_config, ReadOnly, WriteOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result, PAGE_SIZE};
 use alloc::boxed::Box;
 use bitflags::bitflags;
@@ -160,7 +160,8 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
     ///
     /// Returns true if new data has been received.
     pub fn ack_interrupt(&mut self) -> Result<bool> {
-        if !self.transport.ack_interrupt() {
+        let status = self.transport.ack_interrupt();
+        if !status.contains(InterruptStatus::QUEUE_INTERRUPT) {
             return Ok(false);
         }
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -3,7 +3,7 @@
 use crate::config::{read_config, ReadOnly, WriteOnly};
 use crate::hal::{BufferDirection, Dma, Hal};
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{pages, Error, Result, PAGE_SIZE};
 use alloc::boxed::Box;
 use bitflags::bitflags;
@@ -81,7 +81,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -4,7 +4,7 @@ use super::common::Feature;
 use crate::config::{read_config, write_config, ReadOnly, WriteOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::Error;
 use alloc::{boxed::Box, string::String};
 use core::cmp::min;
@@ -62,7 +62,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
     }
 
     /// Acknowledge interrupt and process events.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/net/dev.rs
+++ b/src/device/net/dev.rs
@@ -2,6 +2,7 @@ use alloc::vec;
 
 use super::net_buf::{RxBuffer, TxBuffer};
 use super::{EthernetAddress, VirtIONetRaw};
+use crate::transport::InterruptStatus;
 use crate::{hal::Hal, transport::Transport, Error, Result};
 
 /// Driver for a VirtIO network device.
@@ -41,7 +42,7 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONet<H, T, QUEUE_SIZE> 
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.inner.ack_interrupt()
     }
 

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -3,7 +3,7 @@ use super::{MIN_BUFFER_LEN, NET_HDR_SIZE, QUEUE_RECEIVE, QUEUE_TRANSMIT, SUPPORT
 use crate::config::read_config;
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result};
 use log::{debug, info, warn};
 use zerocopy::IntoBytes;
@@ -58,7 +58,7 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZ
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,6 +1,10 @@
 //! Driver for VirtIO random number generator devices.
 use super::common::Feature;
-use crate::{queue::VirtQueue, transport::Transport, Hal, Result};
+use crate::{
+    queue::VirtQueue,
+    transport::{InterruptStatus, Transport},
+    Hal, Result,
+};
 
 // VirtioRNG only uses one queue
 const QUEUE_IDX: u16 = 0;
@@ -46,7 +50,7 @@ impl<H: Hal, T: Transport> VirtIORng<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 }

--- a/src/device/sound.rs
+++ b/src/device/sound.rs
@@ -7,7 +7,7 @@ use super::common::Feature;
 use crate::{
     config::{read_config, ReadOnly},
     queue::{owning::OwningQueue, VirtQueue},
-    transport::Transport,
+    transport::{InterruptStatus, Transport},
     Error, Hal, Result, PAGE_SIZE,
 };
 use alloc::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
@@ -158,7 +158,7 @@ impl<H: Hal, T: Transport> VirtIOSound<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -3,6 +3,7 @@
 use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
     queue::{fake_read_write_queue, Descriptor},
+    transport::InterruptStatus,
     Error, PhysAddr,
 };
 use alloc::{sync::Arc, vec::Vec};
@@ -93,13 +94,14 @@ impl<C: FromBytes + Immutable + IntoBytes> Transport for FakeTransport<C> {
         self.state.lock().unwrap().queues[queue as usize].descriptors != 0
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         let mut state = self.state.lock().unwrap();
         let pending = state.interrupt_pending;
         if pending {
             state.interrupt_pending = false;
+            return InterruptStatus::QUEUE_INTERRUPT;
         }
-        pending
+        InterruptStatus::empty()
     }
 
     fn read_config_generation(&self) -> u32 {

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -1,7 +1,7 @@
 //! MMIO transport for VirtIO.
 
 use super::{DeviceStatus, DeviceType, DeviceTypeError, Transport};
-use crate::{align_up, queue::Descriptor, Error, PhysAddr, PAGE_SIZE};
+use crate::{align_up, queue::Descriptor, transport::InterruptStatus, Error, PhysAddr, PAGE_SIZE};
 use core::{
     convert::{TryFrom, TryInto},
     mem::{align_of, size_of},
@@ -469,13 +469,13 @@ impl Transport for MmioTransport<'_> {
         }
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         let interrupt = field_shared!(self.header, interrupt_status).read();
         if interrupt != 0 {
             field!(self.header, interrupt_ack).write(interrupt);
-            true
+            InterruptStatus::from_bits_truncate(interrupt)
         } else {
-            false
+            InterruptStatus::empty()
         }
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -69,7 +69,7 @@ pub trait Transport {
     /// Acknowledges an interrupt.
     ///
     /// Returns true on success.
-    fn ack_interrupt(&mut self) -> bool;
+    fn ack_interrupt(&mut self) -> InterruptStatus;
 
     /// Begins initializing the device.
     ///
@@ -172,6 +172,22 @@ bitflags! {
         /// Indicates that the device has experienced an error from which it
         /// can’t recover.
         const DEVICE_NEEDS_RESET = 64;
+    }
+}
+
+/// The set of interrupts which were pending
+///
+/// Ref: 4.1.4.5 ISR status capability
+#[derive(Copy, Clone, Default, Eq, FromBytes, PartialEq)]
+pub struct InterruptStatus(u32);
+
+bitflags! {
+    impl InterruptStatus: u32 {
+        /// Indicates that a virtqueue buffer was used
+        const QUEUE_INTERRUPT = 1 << 0;
+
+        /// Indicates that a virtio device changed its configuration state
+        const DEVICE_CONFIGURATION_INTERRUPT = 1 << 1;
     }
 }
 

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -8,6 +8,7 @@ use self::bus::{
 use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
     hal::{Hal, PhysAddr},
+    transport::InterruptStatus,
     Error,
 };
 use core::{
@@ -298,11 +299,10 @@ impl Transport for PciTransport {
         field_shared!(self.common_cfg, queue_enable).read() == 1
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
         let isr_status = self.isr_status.read();
-        // TODO: Distinguish between queue interrupt and device configuration interrupt.
-        isr_status & 0x3 != 0
+        InterruptStatus::from_bits_retain(isr_status.into())
     }
 
     fn read_config_generation(&self) -> u32 {

--- a/src/transport/some.rs
+++ b/src/transport/some.rs
@@ -1,7 +1,7 @@
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use super::{mmio::MmioTransport, pci::PciTransport, DeviceStatus, DeviceType, Transport};
-use crate::{PhysAddr, Result};
+use crate::{transport::InterruptStatus, PhysAddr, Result};
 
 /// A wrapper for an arbitrary VirtIO transport, either MMIO or PCI.
 #[derive(Debug)]
@@ -143,7 +143,7 @@ impl Transport for SomeTransport<'_> {
         }
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         match self {
             Self::Mmio(mmio) => mmio.ack_interrupt(),
             Self::Pci(pci) => pci.ack_interrupt(),

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -13,7 +13,7 @@ use super::{
     },
     DeviceStatus, DeviceType, Transport,
 };
-use crate::{hal::PhysAddr, Error};
+use crate::{hal::PhysAddr, transport::InterruptStatus, Error};
 pub use cam::HypCam;
 use hypercalls::HypIoRegion;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -237,11 +237,10 @@ impl Transport for HypPciTransport {
         queue_enable == 1
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
         let isr_status: u8 = self.isr_status.read(0);
-        // TODO: Distinguish between queue interrupt and device configuration interrupt.
-        isr_status & 0x3 != 0
+        InterruptStatus::from_bits_truncate(isr_status.into())
     }
 
     fn read_config_generation(&self) -> u32 {

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -238,8 +238,6 @@ impl Transport for HypPciTransport {
     }
 
     fn ack_interrupt(&mut self) -> bool {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
-        // was aligned.
         // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
         let isr_status: u8 = self.isr_status.read(0);
         // TODO: Distinguish between queue interrupt and device configuration interrupt.


### PR DESCRIPTION
This appears to be a known limitation in the current implementation. Without this change, interrupt service routines are unable to tell why they are running (is there a new virtqueue packet to process or did the device confirmation change).

This PR also makes a tiny cleanup change to remove a safety comment that is no longer needed.