### PR TITLE
Add `Arc<SomeTransport>` to `SomeTransport`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-drivers-and-devices"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-drivers-and-devices"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "virtio-drivers"
-version = "0.9.0"
+name = "virtio-drivers-and-devices"
+version = "0.1.0"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",
@@ -9,8 +9,8 @@ authors = [
   "Andrew Walbran <qwandor@google.com>",
 ]
 edition = "2021"
-description = "VirtIO guest drivers."
-repository = "https://github.com/rcore-os/virtio-drivers"
+description = "VirtIO guest drivers and devices. Fork of rcore-os/virtio-drivers."
+repository = "https://github.com/immunant/virtio-drivers-and-devices"
 keywords = ["virtio"]
 categories = ["hardware-support", "no-std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-drivers-and-devices"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-drivers-and-devices"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
   "Runji Wang <wangrunji0408@163.com>",
   "Yuekai Jia <equation618@gmail.com>",
   "Andrew Walbran <qwandor@google.com>",
+  "Ayrton Munoz <ayrton@google.com>",
 ]
 edition = "2021"
 description = "VirtIO guest drivers and devices. Fork of rcore-os/virtio-drivers."

--- a/README.md
+++ b/README.md
@@ -1,71 +1,7 @@
-# VirtIO-drivers-rs
+# VirtIO-drivers-and-devices
 
-[![crates.io page](https://img.shields.io/crates/v/virtio-drivers.svg)](https://crates.io/crates/virtio-drivers)
-[![docs.rs page](https://docs.rs/virtio-drivers/badge.svg)](https://docs.rs/virtio-drivers)
-[![CI](https://github.com/rcore-os/virtio-drivers/workflows/CI/badge.svg?branch=master)](https://github.com/rcore-os/virtio-drivers/actions)
+[![crates.io page](https://img.shields.io/crates/v/virtio-drivers.svg)](https://crates.io/crates/virtio-drivers-and-devices)
 
-VirtIO guest drivers in Rust. For **no_std** environment.
+VirtIO guest drivers and devices in Rust. For **no_std** environment.
+Fork of https://github.com/rcore-os/virtio-drivers.
 
-## Support status
-
-### Device types
-
-| Device  | Supported |
-| ------- | --------- |
-| Block   | ✅        |
-| Net     | ✅        |
-| GPU     | ✅        |
-| Input   | ✅        |
-| Console | ✅        |
-| Socket  | ✅        |
-| Sound   | ✅        |
-| ...     | ❌        |
-
-### Transports
-
-| Transport   | Supported |                                                   |
-| ----------- | --------- | ------------------------------------------------- |
-| Legacy MMIO | ✅        | version 1                                         |
-| MMIO        | ✅        | version 2                                         |
-| PCI         | ✅        | Memory-mapped CAM only, e.g. aarch64 or PCIe ECAM |
-
-### Device-independent features
-
-| Feature flag                 | Supported |                                         |
-| ---------------------------- | --------- | --------------------------------------- |
-| `VIRTIO_F_INDIRECT_DESC`     | ✅        | Indirect descriptors                    |
-| `VIRTIO_F_EVENT_IDX`         | ✅        | `avail_event` and `used_event` fields   |
-| `VIRTIO_F_VERSION_1`         | TODO      | VirtIO version 1 compliance             |
-| `VIRTIO_F_ACCESS_PLATFORM`   | ❌        | Limited device access to memory         |
-| `VIRTIO_F_RING_PACKED`       | ❌        | Packed virtqueue layout                 |
-| `VIRTIO_F_IN_ORDER`          | ❌        | Optimisations for in-order buffer usage |
-| `VIRTIO_F_ORDER_PLATFORM`    | ❌        | Platform ordering for memory access     |
-| `VIRTIO_F_SR_IOV`            | ❌        | Single root I/O virtualization          |
-| `VIRTIO_F_NOTIFICATION_DATA` | ❌        | Extra data in device notifications      |
-
-## Examples & Tests
-
-### [x86_64](./examples/x86_64)
-
-```bash
-cd examples/x86_64
-make qemu
-```
-
-### [aarch64](./examples/aarch64)
-
-```bash
-cd examples/aarch64
-make qemu
-```
-
-### [RISCV](./examples/riscv)
-
-```bash
-cd examples/riscv
-make qemu
-```
-
-You will see device info & GUI Window in qemu.
-
-<img decoding="async" src="https://github.com/rcore-os/virtio-drivers/raw/master/examples/riscv/virtio-test-gpu.png" width="50%">

--- a/examples/aarch64/Cargo.toml
+++ b/examples/aarch64/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4.22"
 pl011-uart = "0.1.0"
 smccc = "0.1.1"
 spin = "0.9.8"
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/examples/aarch64/Makefile
+++ b/examples/aarch64/Makefile
@@ -84,6 +84,7 @@ qemu: $(kernel_qemu_bin) $(img) $(vsock_server_bin)
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device vhost-vsock-device,id=virtiosocket0,guest-cid=102 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-serial,id=virtio-serial0 \
 		-chardev stdio,id=char0,mux=on \
@@ -101,6 +102,7 @@ qemu-pci: $(kernel_qemu_bin) $(img)
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device vhost-vsock-pci,id=virtiosocket0,guest-cid=103 \
 		-device virtio-blk-pci,drive=x0 \
+		-device virtio-rng-pci \
 		-device virtio-gpu-pci \
 		-device virtio-serial,id=virtio-serial0 \
 		-chardev stdio,id=char0,mux=on \

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -1,7 +1,7 @@
 use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
 use core::{alloc::Layout, ptr::NonNull};
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 pub struct HalImpl;
 

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -23,7 +23,7 @@ use flat_device_tree::{node::FdtNode, standard_nodes::Compatible, Fdt};
 use hal::HalImpl;
 use log::{debug, error, info, trace, warn, LevelFilter};
 use smccc::{psci::system_off, Hvc};
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{
         blk::VirtIOBlk,
         console::VirtIOConsole,
@@ -218,7 +218,7 @@ fn virtio_console<T: Transport>(transport: T) {
     info!("virtio-console test finished");
 }
 
-fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers::Result<()> {
+fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers_and_devices::Result<()> {
     let mut socket = VsockConnectionManager::new(
         VirtIOSocket::<HalImpl, T>::new(transport).expect("Failed to create socket driver"),
     );

--- a/examples/riscv/Cargo.toml
+++ b/examples/riscv/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 riscv = "0.10"
 opensbi-rt = { git = "https://github.com/rcore-os/opensbi-rt.git", rev = "abdfeb72" }
 flat_device_tree = "3.1.1"
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 
 [dependencies.smoltcp]

--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -55,6 +55,7 @@ qemu-legacy: kernel $(img)
 		-kernel $(kernel) \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-mouse-device \
 		-device virtio-net-device,netdev=net0 \
@@ -74,6 +75,7 @@ qemu: kernel $(img)
 		-global virtio-mmio.force-legacy=false \
 		-drive file=$(img),if=none,format=raw,id=x0 \
 		-device virtio-blk-device,drive=x0 \
+		-device virtio-rng-device \
 		-device virtio-gpu-device \
 		-device virtio-mouse-device \
 		-device virtio-net-device,netdev=net0 \

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -12,7 +12,7 @@ use alloc::vec;
 use core::ptr::NonNull;
 use flat_device_tree::{node::FdtNode, standard_nodes::Compatible, Fdt};
 use log::LevelFilter;
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{
         blk::VirtIOBlk,
         gpu::VirtIOGpu,
@@ -153,9 +153,12 @@ fn virtio_input<T: Transport>(transport: T) {
 fn virtio_net<T: Transport>(transport: T) {
     #[cfg(not(feature = "tcp"))]
     {
-        let mut net =
-            virtio_drivers::device::net::VirtIONetRaw::<HalImpl, T, NET_QUEUE_SIZE>::new(transport)
-                .expect("failed to create net driver");
+        let mut net = virtio_drivers_and_devices::device::net::VirtIONetRaw::<
+            HalImpl,
+            T,
+            NET_QUEUE_SIZE,
+        >::new(transport)
+        .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
 
         let mut buf = [0u8; 2048];
@@ -172,11 +175,12 @@ fn virtio_net<T: Transport>(transport: T) {
     #[cfg(feature = "tcp")]
     {
         const NET_BUFFER_LEN: usize = 2048;
-        let net = virtio_drivers::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
-            transport,
-            NET_BUFFER_LEN,
-        )
-        .expect("failed to create net driver");
+        let net =
+            virtio_drivers_and_devices::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
+                transport,
+                NET_BUFFER_LEN,
+            )
+            .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
         tcp::test_echo_server(net);
     }

--- a/examples/riscv/src/tcp.rs
+++ b/examples/riscv/src/tcp.rs
@@ -9,8 +9,8 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 use smoltcp::{socket::tcp, time::Instant};
-use virtio_drivers::device::net::{RxBuffer, VirtIONet};
-use virtio_drivers::{transport::Transport, Error};
+use virtio_drivers_and_devices::device::net::{RxBuffer, VirtIONet};
+use virtio_drivers_and_devices::{transport::Transport, Error};
 
 use super::{HalImpl, NET_QUEUE_SIZE};
 

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     fn end();

--- a/examples/x86_64/Cargo.toml
+++ b/examples/x86_64/Cargo.toml
@@ -18,7 +18,7 @@ x86_64 = { version = "0.14.12", default-features = false, features = [
 uart_16550 = "0.2"
 linked_list_allocator = "0.10"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 
 [dependencies.smoltcp]
 version = "0.9.1"

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -26,6 +26,7 @@ QEMU_ARGS += \
 	-kernel $(kernel) \
 	-device virtio-gpu-pci -vga none \
 	-device virtio-blk-pci,drive=x0 -drive file=$(img),if=none,format=raw,id=x0 \
+	-device virtio-rng-pci \
 	-device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::5555-:5555
 
 ifeq ($(accel), on)

--- a/examples/x86_64/src/hal.rs
+++ b/examples/x86_64/src/hal.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     static dma_region: u8;

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -17,7 +17,7 @@ mod trap;
 mod tcp;
 
 use self::hal::HalImpl;
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{blk::VirtIOBlk, gpu::VirtIOGpu},
     transport::{
         pci::{
@@ -118,9 +118,12 @@ fn virtio_gpu<T: Transport>(transport: T) {
 fn virtio_net<T: Transport>(transport: T) {
     #[cfg(not(feature = "tcp"))]
     {
-        let mut net =
-            virtio_drivers::device::net::VirtIONetRaw::<HalImpl, T, NET_QUEUE_SIZE>::new(transport)
-                .expect("failed to create net driver");
+        let mut net = virtio_drivers_and_devices::device::net::VirtIONetRaw::<
+            HalImpl,
+            T,
+            NET_QUEUE_SIZE,
+        >::new(transport)
+        .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
 
         let mut buf = [0u8; 2048];
@@ -137,11 +140,12 @@ fn virtio_net<T: Transport>(transport: T) {
     #[cfg(feature = "tcp")]
     {
         const NET_BUFFER_LEN: usize = 2048;
-        let net = virtio_drivers::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
-            transport,
-            NET_BUFFER_LEN,
-        )
-        .expect("failed to create net driver");
+        let net =
+            virtio_drivers_and_devices::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
+                transport,
+                NET_BUFFER_LEN,
+            )
+            .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
         tcp::test_echo_server(net);
     }

--- a/examples/x86_64/src/tcp.rs
+++ b/examples/x86_64/src/tcp.rs
@@ -9,8 +9,8 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 use smoltcp::{socket::tcp, time::Instant};
-use virtio_drivers::device::net::{RxBuffer, VirtIONet};
-use virtio_drivers::{transport::Transport, Error};
+use virtio_drivers_and_devices::device::net::{RxBuffer, VirtIONet};
+use virtio_drivers_and_devices::{transport::Transport, Error};
 
 use super::{HalImpl, NET_QUEUE_SIZE};
 

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -3,7 +3,7 @@
 use crate::config::{read_config, ReadOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result};
 use bitflags::bitflags;
 use log::info;
@@ -90,7 +90,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// Acknowledges a pending interrupt, if any.
     ///
     /// Returns true if there was an interrupt to acknowledge.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -26,9 +26,9 @@ const SUPPORTED_FEATURES: BlkFeature = BlkFeature::RO
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal};
-/// # use virtio_drivers::transport::Transport;
-/// use virtio_drivers::device::blk::{VirtIOBlk, SECTOR_SIZE};
+/// # use virtio_drivers_and_devices::{Error, Hal};
+/// # use virtio_drivers_and_devices::transport::Transport;
+/// use virtio_drivers_and_devices::device::blk::{VirtIOBlk, SECTOR_SIZE};
 ///
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut disk = VirtIOBlk::<HalImpl, _>::new(transport)?;
@@ -212,10 +212,10 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// the same buffers before reading the response.
     ///
     /// ```
-    /// # use virtio_drivers::{Error, Hal};
-    /// # use virtio_drivers::device::blk::VirtIOBlk;
-    /// # use virtio_drivers::transport::Transport;
-    /// use virtio_drivers::device::blk::{BlkReq, BlkResp, RespStatus};
+    /// # use virtio_drivers_and_devices::{Error, Hal};
+    /// # use virtio_drivers_and_devices::device::blk::VirtIOBlk;
+    /// # use virtio_drivers_and_devices::transport::Transport;
+    /// use virtio_drivers_and_devices::device::blk::{BlkReq, BlkResp, RespStatus};
     ///
     /// # fn example<H: Hal, T: Transport>(blk: &mut VirtIOBlk<H, T>) -> Result<(), Error> {
     /// let mut request = BlkReq::default();

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -29,8 +29,8 @@ const SUPPORTED_FEATURES: Features = Features::RING_EVENT_IDX
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal, transport::Transport};
-/// use virtio_drivers::device::console::VirtIOConsole;
+/// # use virtio_drivers_and_devices::{Error, Hal, transport::Transport};
+/// use virtio_drivers_and_devices::device::console::VirtIOConsole;
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut console = VirtIOConsole::<HalImpl, _>::new(transport)?;
 ///

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -142,7 +142,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
     /// receive request or some data already received and not yet returned.
     fn poll_retrieve(&mut self) -> Result<()> {
         if self.receive_token.is_none() && self.cursor == self.pending_len {
-            // Safe because the buffer lasts at least as long as the queue, and there are no other
+            // SAFETY: The buffer lasts at least as long as the queue, and there are no other
             // outstanding requests using the buffer.
             self.receive_token = Some(unsafe {
                 self.receiveq
@@ -174,7 +174,7 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
         let mut flag = false;
         if let Some(receive_token) = self.receive_token {
             if self.receive_token == self.receiveq.peek_used() {
-                // Safe because we are passing the same buffer as we passed to `VirtQueue::add` in
+                // SAFETY: We are passing the same buffer as we passed to `VirtQueue::add` in
                 // `poll_retrieve` and it is still valid.
                 let len = unsafe {
                     self.receiveq.pop_used(

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -6,7 +6,7 @@ mod embedded_io;
 use crate::config::{read_config, write_config, ReadOnly, WriteOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result, PAGE_SIZE};
 use alloc::boxed::Box;
 use bitflags::bitflags;
@@ -160,7 +160,8 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
     ///
     /// Returns true if new data has been received.
     pub fn ack_interrupt(&mut self) -> Result<bool> {
-        if !self.transport.ack_interrupt() {
+        let status = self.transport.ack_interrupt();
+        if !status.contains(InterruptStatus::QUEUE_INTERRUPT) {
             return Ok(false);
         }
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -115,12 +115,13 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // map frame buffer to screen
         self.set_scanout(display_info.rect, SCANOUT_ID, RESOURCE_ID_FB)?;
 
-        // SAFETY: The pointer returned from `raw_slice` is guaranteed to be
-        // non-null, aligned, and a valid allocation. We store the `Dma` object
-        // in `self.frame_buffer_dma`, which prevents the allocation from being
-        // freed while `self` exists. The returned ptr borrows `self` mutably,
-        // which prevents other code from getting another reference to
-        // `frame_buffer_dma` while the returned slice is still in use.
+        // SAFETY: `Dma::new` guarantees that the pointer returned from
+        // `raw_slice` is non-null, aligned, and the allocation is zeroed. We
+        // store the `Dma` object in `self.frame_buffer_dma`, which prevents the
+        // allocation from being freed while `self` exists. The returned ptr
+        // borrows `self` mutably, which prevents other code from getting
+        // another reference to `frame_buffer_dma` while the returned slice is
+        // still in use.
         let buf = unsafe { frame_buffer_dma.raw_slice().as_mut() };
         self.frame_buffer_dma = Some(frame_buffer_dma);
         Ok(buf)
@@ -150,6 +151,11 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             return Err(Error::InvalidParam);
         }
         let cursor_buffer_dma = Dma::new(pages(size as usize), BufferDirection::DriverToDevice)?;
+
+        // SAFETY: `Dma::new` guarantees that the pointer returned from
+        // `raw_slice` is non-null, aligned, and the allocation is zeroed. The
+        // returned reference is only used within this function while
+        // `cursor_buffer_dma` is alive.
         let buf = unsafe { cursor_buffer_dma.raw_slice().as_mut() };
         buf.copy_from_slice(cursor_image);
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -1,7 +1,7 @@
 //! Driver for VirtIO GPU devices.
 
 use crate::config::{read_config, ReadOnly, WriteOnly};
-use crate::hal::{BufferDirection, Dma, Hal};
+use crate::hal::{BufferDirection, Dma, DmaMemory, Hal};
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
 use crate::{pages, Error, Result, PAGE_SIZE};

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -3,7 +3,7 @@
 use crate::config::{read_config, ReadOnly, WriteOnly};
 use crate::hal::{BufferDirection, Dma, DmaMemory, Hal};
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{pages, Error, Result, PAGE_SIZE};
 use alloc::boxed::Box;
 use bitflags::bitflags;
@@ -81,7 +81,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -115,6 +115,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // map frame buffer to screen
         self.set_scanout(display_info.rect, SCANOUT_ID, RESOURCE_ID_FB)?;
 
+        // SAFETY: The pointer returned from `raw_slice` is guaranteed to be
+        // non-null, aligned, and a valid allocation. We store the `Dma` object
+        // in `self.frame_buffer_dma`, which prevents the allocation from being
+        // freed while `self` exists. The returned ptr borrows `self` mutably,
+        // which prevents other code from getting another reference to
+        // `frame_buffer_dma` while the returned slice is still in use.
         let buf = unsafe { frame_buffer_dma.raw_slice().as_mut() };
         self.frame_buffer_dma = Some(frame_buffer_dma);
         Ok(buf)

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -4,7 +4,7 @@ use super::common::Feature;
 use crate::config::{read_config, write_config, ReadOnly, WriteOnly};
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::Error;
 use alloc::{boxed::Box, string::String};
 use core::cmp::min;
@@ -62,7 +62,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
     }
 
     /// Acknowledge interrupt and process events.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -43,7 +43,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             negotiated_features.contains(Feature::RING_EVENT_IDX),
         )?;
         for (i, event) in event_buf.as_mut().iter_mut().enumerate() {
-            // Safe because the buffer lasts as long as the queue.
+            // SAFETY: The buffer lasts as long as the queue.
             let token = unsafe { event_queue.add(&[], &mut [event.as_mut_bytes()])? };
             assert_eq!(token, i as u16);
         }
@@ -70,8 +70,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
     pub fn pop_pending_event(&mut self) -> Option<InputEvent> {
         if let Some(token) = self.event_queue.peek_used() {
             let event = &mut self.event_buf[token as usize];
-            // Safe because we are passing the same buffer as we passed to `VirtQueue::add` and it
-            // is still valid.
+            // SAFETY: We are passing the same buffer as we passed to `VirtQueue::add` and it is still valid.
             unsafe {
                 self.event_queue
                     .pop_used(token, &[], &mut [event.as_mut_bytes()])
@@ -79,7 +78,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
             }
             let event_saved = *event;
             // requeue
-            // Safe because buffer lasts as long as the queue.
+            // SAFETY: The buffer lasts as long as the queue.
             if let Ok(new_token) = unsafe { self.event_queue.add(&[], &mut [event.as_mut_bytes()]) }
             {
                 // This only works because nothing happen between `pop_used` and `add` that affects

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -10,6 +10,8 @@ pub mod input;
 
 pub mod net;
 
+pub mod rng;
+
 pub mod socket;
 #[cfg(feature = "alloc")]
 pub mod sound;

--- a/src/device/net/dev.rs
+++ b/src/device/net/dev.rs
@@ -2,6 +2,7 @@ use alloc::vec;
 
 use super::net_buf::{RxBuffer, TxBuffer};
 use super::{EthernetAddress, VirtIONetRaw};
+use crate::transport::InterruptStatus;
 use crate::{hal::Hal, transport::Transport, Error, Result};
 
 /// Driver for a VirtIO network device.
@@ -41,7 +42,7 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONet<H, T, QUEUE_SIZE> 
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.inner.ack_interrupt()
     }
 

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -3,7 +3,7 @@ use super::{MIN_BUFFER_LEN, NET_HDR_SIZE, QUEUE_RECEIVE, QUEUE_TRANSMIT, SUPPORT
 use crate::config::read_config;
 use crate::hal::Hal;
 use crate::queue::VirtQueue;
-use crate::transport::Transport;
+use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, Result};
 use log::{debug, info, warn};
 use zerocopy::IntoBytes;
@@ -58,7 +58,7 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZ
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/device/net/net_buf.rs
+++ b/src/device/net/net_buf.rs
@@ -1,7 +1,7 @@
 use super::{VirtioNetHdr, NET_HDR_SIZE};
 use alloc::{vec, vec::Vec};
 use core::{convert::TryInto, mem::size_of};
-use zerocopy::IntoBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 /// A buffer used for transmitting.
 pub struct TxBuffer(pub(crate) Vec<u8>);
@@ -68,7 +68,7 @@ impl RxBuffer {
 
     /// Returns the reference of the header.
     pub fn header(&self) -> &VirtioNetHdr {
-        unsafe { &*(self.buf.as_ptr() as *const VirtioNetHdr) }
+        FromBytes::ref_from_prefix(self.as_bytes()).unwrap().0
     }
 
     /// Returns the network packet as a slice.

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,0 +1,58 @@
+//! Driver for VirtIO random number generator devices.
+use super::common::Feature;
+use crate::{queue::VirtQueue, transport::Transport, Hal, Result};
+
+// VirtioRNG only uses one queue
+const QUEUE_IDX: u16 = 0;
+const QUEUE_SIZE: usize = 8;
+const SUPPORTED_FEATURES: Feature = Feature::RING_INDIRECT_DESC.union(Feature::RING_EVENT_IDX);
+
+/// Driver for a VirtIO random number generator device.
+pub struct VirtIORng<H: Hal, T: Transport> {
+    transport: T,
+    queue: VirtQueue<H, QUEUE_SIZE>,
+}
+
+impl<H: Hal, T: Transport> VirtIORng<H, T> {
+    /// Create a new driver with the given transport.
+    pub fn new(mut transport: T) -> Result<Self> {
+        let feat = transport.begin_init(SUPPORTED_FEATURES);
+        let queue = VirtQueue::new(
+            &mut transport,
+            QUEUE_IDX,
+            feat.contains(Feature::RING_INDIRECT_DESC),
+            feat.contains(Feature::RING_EVENT_IDX),
+        )?;
+        transport.finish_init();
+        Ok(Self { transport, queue })
+    }
+
+    /// Request random bytes from the device to be stored into `dst`.
+    pub fn request_entropy(&mut self, dst: &mut [u8]) -> Result<usize> {
+        let num = self
+            .queue
+            .add_notify_wait_pop(&[], &mut [dst], &mut self.transport)?;
+        Ok(num as usize)
+    }
+
+    /// Enable interrupts.
+    pub fn enable_interrupts(&mut self) {
+        self.queue.set_dev_notify(true);
+    }
+
+    /// Disable interrupts.
+    pub fn disable_interrupts(&mut self) {
+        self.queue.set_dev_notify(false);
+    }
+
+    /// Acknowledge interrupt.
+    pub fn ack_interrupt(&mut self) -> bool {
+        self.transport.ack_interrupt()
+    }
+}
+
+impl<H: Hal, T: Transport> Drop for VirtIORng<H, T> {
+    fn drop(&mut self) {
+        self.transport.queue_unset(QUEUE_IDX);
+    }
+}

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,6 +1,10 @@
 //! Driver for VirtIO random number generator devices.
 use super::common::Feature;
-use crate::{queue::VirtQueue, transport::Transport, Hal, Result};
+use crate::{
+    queue::VirtQueue,
+    transport::{InterruptStatus, Transport},
+    Hal, Result,
+};
 
 // VirtioRNG only uses one queue
 const QUEUE_IDX: u16 = 0;
@@ -46,7 +50,7 @@ impl<H: Hal, T: Transport> VirtIORng<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 }

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -25,9 +25,9 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal};
-/// # use virtio_drivers::transport::Transport;
-/// use virtio_drivers::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
+/// # use virtio_drivers_and_devices::{Error, Hal};
+/// # use virtio_drivers_and_devices::transport::Transport;
+/// use virtio_drivers_and_devices::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
 ///
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _>::new(transport)?);

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -15,7 +15,7 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager};
+pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager, VsockManager};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -21,6 +21,9 @@ pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]
 pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
 
+#[cfg(feature = "alloc")]
+pub(crate) use vsock::VirtIOSocketManager;
+
 /// The size in bytes of each buffer used in the RX virtqueue. This must be bigger than
 /// `size_of::<VirtioVsockHdr>()`.
 const DEFAULT_RX_BUFFER_SIZE: usize = 512;

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -19,7 +19,9 @@ pub use connectionmanager::VsockConnectionManager;
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]
-pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
+pub use vsock::{
+    ConnectionInfo, DisconnectReason, VirtIOSocket, VirtIOSocketDevice, VsockEvent, VsockEventType,
+};
 
 #[cfg(feature = "alloc")]
 pub(crate) use vsock::VirtIOSocketManager;

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -15,7 +15,7 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::VsockConnectionManager;
+pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -405,6 +405,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
     }
 }
 
+/// A low-level interface for a vsock device implementation
 pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport> {
     transport: T,
     rx: DeviceVirtQueue<H, { QUEUE_SIZE }>,
@@ -413,6 +414,7 @@ pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport> {
 }
 
 impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketDevice<H, T> {
+    /// Create a new VirtIO Vsock device.
     pub fn new(mut transport: T) -> Result<Self> {
         let rx = DeviceVirtQueue::new(&mut transport, RX_QUEUE_IDX)?;
         let tx = DeviceVirtQueue::new(&mut transport, TX_QUEUE_IDX)?;

--- a/src/device/sound.rs
+++ b/src/device/sound.rs
@@ -7,7 +7,7 @@ use super::common::Feature;
 use crate::{
     config::{read_config, ReadOnly},
     queue::{owning::OwningQueue, VirtQueue},
-    transport::Transport,
+    transport::{InterruptStatus, Transport},
     Error, Hal, Result, PAGE_SIZE,
 };
 use alloc::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
@@ -158,7 +158,7 @@ impl<H: Hal, T: Transport> VirtIOSound<H, T> {
     }
 
     /// Acknowledge interrupt.
-    pub fn ack_interrupt(&mut self) -> bool {
+    pub fn ack_interrupt(&mut self) -> InterruptStatus {
         self.transport.ack_interrupt()
     }
 

--- a/src/embedded_io.rs
+++ b/src/embedded_io.rs
@@ -6,7 +6,7 @@ use embedded_io::ErrorKind;
 impl embedded_io::Error for Error {
     fn kind(&self) -> ErrorKind {
         match self {
-            Error::InvalidParam => ErrorKind::InvalidInput,
+            Error::InvalidDescriptor | Error::InvalidParam => ErrorKind::InvalidInput,
             Error::DmaError => ErrorKind::OutOfMemory,
             Error::Unsupported => ErrorKind::Unsupported,
             Error::SocketDeviceError(e) => match e {

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -70,8 +70,8 @@ impl<H: Hal> DmaMemory for Dma<H> {
 
 impl<H: Hal> Drop for Dma<H> {
     fn drop(&mut self) {
-        // Safe because the memory was previously allocated by `dma_alloc` in `Dma::new`, not yet
-        // deallocated, and we are passing the values from then.
+        // SAFETY: The memory was previously allocated by `dma_alloc` in `Dma::new`,
+        // not yet deallocated, and we are passing the values from then.
         let err = unsafe { H::dma_dealloc(self.paddr, self.vaddr, self.pages) };
         assert_eq!(err, 0, "failed to deallocate DMA");
     }

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -2,6 +2,7 @@
 pub mod fake;
 
 use crate::{Error, Result, PAGE_SIZE};
+use core::cmp::PartialEq;
 use core::{marker::PhantomData, ptr::NonNull};
 
 /// A physical address as used for virtio.
@@ -92,6 +93,15 @@ unsafe impl<H: DeviceHal> Send for DeviceDma<H> {}
 // SAFETY: `&DeviceDma` only allows pointers and physical addresses to be returned. Any accesses to
 // the memory requires unsafe code, which is responsible for avoiding data races.
 unsafe impl<H: DeviceHal> Sync for DeviceDma<H> {}
+
+impl<H: DeviceHal> PartialEq for DeviceDma<H> {
+    fn eq(&self, other: &Self) -> bool {
+        let paddrs_match = self.paddr == other.paddr;
+        let vaddrs_match = self.vaddr == other.vaddr;
+        let num_pages_match = self.pages == other.pages;
+        paddrs_match && vaddrs_match && num_pages_match
+    }
+}
 
 impl<H: DeviceHal> DeviceDma<H> {
     // SAFETY: The caller must ensure that the memory described by paddr and pages can be mapped by

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -140,6 +140,15 @@ pub unsafe trait Hal {
     unsafe fn unshare(paddr: PhysAddr, buffer: NonNull<[u8]>, direction: BufferDirection);
 }
 
+// TODO: document safety requirements
+/// Device-side abstraction layer for mapping and unmapping memory shared by the driver.
+pub trait DeviceHal {
+    /// Maps in memory shared by the driver.
+    unsafe fn dma_map(paddr: PhysAddr, pages: usize, direction: BufferDirection) -> Result<NonNull<u8>>;
+    /// Unmaps in memory previously shared by the driver.
+    unsafe fn dma_unmap(paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32;
+}
+
 /// The direction in which a buffer is passed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BufferDirection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
-#![deny(unused_must_use, missing_docs)]
+#![deny(unused_must_use, missing_docs, clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::identity_op)]
 #![allow(dead_code)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ use core::ptr::{self, NonNull};
 use device::socket::SocketError;
 use thiserror::Error;
 
-pub use self::hal::{BufferDirection, Hal, PhysAddr};
+pub use self::hal::{BufferDirection, DeviceHal, Hal, PhysAddr};
 
 /// The page size in bytes supported by the library (4 KiB).
 pub const PAGE_SIZE: usize = 0x1000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! use core::ptr::NonNull;
-//! use virtio_drivers::transport::mmio::{MmioTransport, VirtIOHeader};
+//! use virtio_drivers_and_devices::transport::mmio::{MmioTransport, VirtIOHeader};
 //!
 //! # fn example(mmio_device_address: usize, mmio_size: usize) {
 //! let header = NonNull::new(mmio_device_address as *mut VirtIOHeader).unwrap();
@@ -23,9 +23,9 @@
 //! You can then check what kind of VirtIO device it is and construct the appropriate driver:
 //!
 //! ```
-//! # use virtio_drivers::Hal;
+//! # use virtio_drivers_and_devices::Hal;
 //! # #[cfg(feature = "alloc")]
-//! use virtio_drivers::{
+//! use virtio_drivers_and_devices::{
 //!     device::console::VirtIOConsole,
 //!     transport::{mmio::MmioTransport, DeviceType, Transport},
 //! };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@ pub enum Error {
     /// Error from the socket device.
     #[error("Error from the socket device: {0}")]
     SocketDeviceError(#[from] SocketError),
+    /// Invalid descriptor or descriptor chain.
+    #[error("Popped an invalid descriptor or descriptor chain")]
+    InvalidDescriptor,
 }
 
 #[cfg(feature = "alloc")]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -666,6 +666,10 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
             // vring and not accessed again.
             let (_read_buffers, mut write_buffers, token) = unsafe { self.pop_avail()?.unwrap() };
 
+            if write_buffers.is_empty() {
+                return Err(Error::NotReady);
+            }
+
             let out_buf = &mut write_buffers[0];
             let mut copied = 0;
             for in_buf in inputs {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -722,6 +722,13 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
                 return Ok(None);
             };
 
+            // A mix of write and read buffers is currently not supported
+            // TODO: Support popping chains of mixed descriptors by caching any write buffers popped
+            // here.
+            if !popped.write_buffers.is_empty() {
+                return Err(Error::Unsupported);
+            }
+
             let mut tmp = Vec::new();
             for in_buf in &popped.read_buffers {
                 tmp.extend_from_slice(in_buf);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -775,6 +775,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
             } else {
                 true
             };
+            let avail_len = desc.len as usize;
             if desc_changed {
                 // SAFETY: desc was read from the virtqueue descriptor table and is currently not in
                 // use since it was either obtained by getting the next available index from
@@ -785,7 +786,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
             }
             let mut buffer = mapped_desc.as_ref().unwrap().dma.raw_slice();
             // SAFETY: Safety delegated to safety requirements on this function.
-            let buffer = unsafe { buffer.as_mut() };
+            let buffer = unsafe { &mut buffer.as_mut()[0..avail_len] };
             res.push(buffer);
         }
         self.avail_idx = self.avail_idx.wrapping_add(1);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "alloc")]
 pub mod owning;
 
-use crate::hal::{BufferDirection, Dma, Hal, PhysAddr};
+use crate::hal::{BufferDirection, Dma, DmaMemory, Hal, PhysAddr};
 use crate::transport::Transport;
 use crate::{align_up, nonnull_slice_from_raw_parts, pages, Error, Result, PAGE_SIZE};
 #[cfg(feature = "alloc")]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -442,8 +442,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
 
                 // SAFETY: `paddr` comes from a previous call `H::share` (inside
                 // `Descriptor::set_buf`, which was called from `add_direct` or `add_indirect`).
-                // `indirect_list` is owned by this function and is not accessed from any other
-                // threads.
+                // `indirect_list` is owned by this function and is not accessed from any other threads.
                 unsafe {
                     H::unshare(
                         paddr as usize,
@@ -542,6 +541,8 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         self.last_used_idx = self.last_used_idx.wrapping_add(1);
 
         if self.event_idx {
+            // SAFETY: `self.avail` points to a valid, aligned, initialised, dereferenceable,
+            // readable instance of `AvailRing`.
             unsafe {
                 (*self.avail.as_ptr())
                     .used_event

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -704,8 +704,9 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
             }
             let result = handler(tmp.as_slice());
 
-            let head_len = read_buffers[0].len();
-            self.add_used(token, head_len);
+            self.add_used(
+                token, 0, /* zero bytes were written to the write buffers */
+            );
 
             if self.should_notify() {
                 transport.notify(self.queue_idx);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -280,6 +280,9 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         // responsible for freeing the memory after the buffer chain is popped.
         let direct_desc = &mut self.desc_shadow[usize::from(head)];
         self.free_head = direct_desc.next;
+
+        // SAFETY: Using `Box::leak` on `indirect_list` guarantees it won't be deallocated
+        // while in use.
         unsafe {
             direct_desc.set_buf::<H>(
                 Box::leak(indirect_list).as_bytes().into(),

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -818,6 +818,11 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
                 let buffer = unsafe { &mut buffer.as_mut()[0..avail_len] };
                 write_buffers.push(buffer);
             } else {
+                // All read descriptors must come before write descriptors so if we've seen any
+                // write descriptors error out.
+                if !write_buffers.is_empty() {
+                    return Err(Error::InvalidDescriptor);
+                }
                 // SAFETY: Safety delegated to safety requirements on this function.
                 let buffer = unsafe { &buffer.as_ref()[0..avail_len] };
                 read_buffers.push(buffer);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -732,6 +732,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
     ///
     /// The caller must ensure that the returned buffers are not accessed after the first buffer's
     /// token has been written to the used vring and the `last_used` index has been updated.
+    #[cfg(feature = "alloc")]
     unsafe fn pop_avail<'a>(&mut self) -> Result<Option<(Vec<&'a mut [u8]>, u16)>> {
         let Some(head) = self.peek_avail() else {
             return Ok(None);

--- a/src/queue/owning.rs
+++ b/src/queue/owning.rs
@@ -146,7 +146,7 @@ impl<H: Hal, const SIZE: usize, const BUFFER_SIZE: usize> Drop
 {
     fn drop(&mut self) {
         for buffer in self.buffers {
-            // Safe because we obtained the buffer pointer from Box::into_raw, and it won't be used
+            // SAFETY: We obtained the buffer pointer from `Box::into_raw`, and it won't be used
             // anywhere else after the queue is destroyed.
             unsafe { drop(Box::from_raw(buffer.as_ptr())) };
         }

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -3,6 +3,7 @@
 use super::{DeviceStatus, DeviceTransport, DeviceType, Transport};
 use crate::{
     queue::{fake_read_write_queue, Descriptor},
+    transport::InterruptStatus,
     Error, PhysAddr,
 };
 use alloc::{sync::Arc, vec::Vec};
@@ -119,13 +120,14 @@ impl<C: FromBytes + Immutable + IntoBytes> Transport for FakeTransport<C> {
         self.state.lock().unwrap().queues[queue as usize].descriptors != 0
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         let mut state = self.state.lock().unwrap();
         let pending = state.interrupt_pending;
         if pending {
             state.interrupt_pending = false;
+            return InterruptStatus::QUEUE_INTERRUPT;
         }
-        pending
+        InterruptStatus::empty()
     }
 
     fn read_config_generation(&self) -> u32 {

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -304,7 +304,7 @@ impl MmioTransport {
 
     /// Gets the vendor ID.
     pub fn vendor_id(&self) -> u32 {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe { volread!(self.header, vendor_id) }
     }
 }
@@ -318,13 +318,13 @@ unsafe impl Sync for MmioTransport {}
 
 impl Transport for MmioTransport {
     fn device_type(&self) -> DeviceType {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         let device_id = unsafe { volread!(self.header, device_id) };
         device_id.into()
     }
 
     fn read_device_features(&mut self) -> u64 {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, device_features_sel, 0); // device features [0, 32)
             let mut device_features_bits = volread!(self.header, device_features).into();
@@ -335,7 +335,7 @@ impl Transport for MmioTransport {
     }
 
     fn write_driver_features(&mut self, driver_features: u64) {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, driver_features_sel, 0); // driver features [0, 32)
             volwrite!(self.header, driver_features, driver_features as u32);
@@ -345,7 +345,7 @@ impl Transport for MmioTransport {
     }
 
     fn max_queue_size(&mut self, queue: u16) -> u32 {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, queue_sel, queue.into());
             volread!(self.header, queue_num_max)
@@ -353,19 +353,19 @@ impl Transport for MmioTransport {
     }
 
     fn notify(&mut self, queue: u16) {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, queue_notify, queue.into());
         }
     }
 
     fn get_status(&self) -> DeviceStatus {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe { volread!(self.header, status) }
     }
 
     fn set_status(&mut self, status: DeviceStatus) {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, status, status);
         }
@@ -374,7 +374,7 @@ impl Transport for MmioTransport {
     fn set_guest_page_size(&mut self, guest_page_size: u32) {
         match self.version {
             MmioVersion::Legacy => {
-                // Safe because self.header points to a valid VirtIO MMIO region.
+                // SAFETY: `self.header` points to a valid VirtIO MMIO region.
                 unsafe {
                     volwrite!(self.header, legacy_guest_page_size, guest_page_size);
                 }
@@ -416,7 +416,7 @@ impl Transport for MmioTransport {
                 let align = PAGE_SIZE as u32;
                 let pfn = (descriptors / PAGE_SIZE) as u32;
                 assert_eq!(pfn as usize * PAGE_SIZE, descriptors);
-                // Safe because self.header points to a valid VirtIO MMIO region.
+                // SAFETY: `self.header` points to a valid VirtIO MMIO region.
                 unsafe {
                     volwrite!(self.header, queue_sel, queue.into());
                     volwrite!(self.header, queue_num, size);
@@ -425,7 +425,7 @@ impl Transport for MmioTransport {
                 }
             }
             MmioVersion::Modern => {
-                // Safe because self.header points to a valid VirtIO MMIO region.
+                // SAFETY: `self.header` points to a valid VirtIO MMIO region.
                 unsafe {
                     volwrite!(self.header, queue_sel, queue.into());
                     volwrite!(self.header, queue_num, size);
@@ -444,7 +444,7 @@ impl Transport for MmioTransport {
     fn queue_unset(&mut self, queue: u16) {
         match self.version {
             MmioVersion::Legacy => {
-                // Safe because self.header points to a valid VirtIO MMIO region.
+                // SAFETY: `self.header` points to a valid VirtIO MMIO region.
                 unsafe {
                     volwrite!(self.header, queue_sel, queue.into());
                     volwrite!(self.header, queue_num, 0);
@@ -453,7 +453,7 @@ impl Transport for MmioTransport {
                 }
             }
             MmioVersion::Modern => {
-                // Safe because self.header points to a valid VirtIO MMIO region.
+                // SAFETY: `self.header` points to a valid VirtIO MMIO region.
                 unsafe {
                     volwrite!(self.header, queue_sel, queue.into());
 
@@ -474,7 +474,7 @@ impl Transport for MmioTransport {
     }
 
     fn queue_used(&mut self, queue: u16) -> bool {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, queue_sel, queue.into());
             match self.version {
@@ -485,7 +485,7 @@ impl Transport for MmioTransport {
     }
 
     fn ack_interrupt(&mut self) -> bool {
-        // Safe because self.header points to a valid VirtIO MMIO region.
+        // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             let interrupt = volread!(self.header, interrupt_status);
             if interrupt != 0 {

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -4,6 +4,7 @@ use super::{DeviceStatus, DeviceType, Transport};
 use crate::{
     align_up,
     queue::Descriptor,
+    transport::InterruptStatus,
     volatile::{volread, volwrite, ReadOnly, Volatile, WriteOnly},
     Error, PhysAddr, PAGE_SIZE,
 };
@@ -484,15 +485,15 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             let interrupt = volread!(self.header, interrupt_status);
             if interrupt != 0 {
                 volwrite!(self.header, interrupt_ack, interrupt);
-                true
+                InterruptStatus::from_bits_truncate(interrupt)
             } else {
-                false
+                InterruptStatus::empty()
             }
         }
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,6 +17,9 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// A VirtIO device-side transport layer.
 pub trait DeviceTransport {
+    /// Gets the client VM ID
+    fn get_client_id(&self) -> u16;
+
     /// Gets the max size of the given queue.
     fn max_queue_size(&mut self, queue: u16) -> u32;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -15,6 +15,23 @@ use log::debug;
 pub use some::SomeTransport;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
+/// A VirtIO device-side transport layer.
+pub trait DeviceTransport {
+    /// Gets the max size of the given queue.
+    fn max_queue_size(&mut self, queue: u16) -> u32;
+
+    /// Returns whether the transport requires queues to use the legacy layout.
+    ///
+    /// Ref: 2.6.2 Legacy Interfaces: A Note on Virtqueue Layout
+    fn requires_legacy_layout(&self) -> bool;
+
+    /// Gets the physical addresses for descriptors, driver area and device area for a given queue.
+    fn queue_get(&mut self, queue: u16) -> [PhysAddr; 3];
+
+    /// Notifies the given queue on the device.
+    fn notify(&mut self, queue: u16);
+}
+
 /// A VirtIO transport layer.
 pub trait Transport {
     /// Gets the device type.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -85,7 +85,7 @@ pub trait Transport {
     /// Acknowledges an interrupt.
     ///
     /// Returns true on success.
-    fn ack_interrupt(&mut self) -> bool;
+    fn ack_interrupt(&mut self) -> InterruptStatus;
 
     /// Begins initializing the device.
     ///
@@ -177,6 +177,22 @@ bitflags! {
         /// Indicates that the device has experienced an error from which it
         /// can’t recover.
         const DEVICE_NEEDS_RESET = 64;
+    }
+}
+
+/// The set of interrupts which were pending
+///
+/// Ref: 4.1.4.5 ISR status capability
+#[derive(Copy, Clone, Default, Eq, FromBytes, PartialEq)]
+pub struct InterruptStatus(u32);
+
+bitflags! {
+    impl InterruptStatus: u32 {
+        /// Indicates that a virtqueue buffer was used
+        const QUEUE_INTERRUPT = 1 << 0;
+
+        /// Indicates that a virtio device changed its configuration state
+        const DEVICE_CONFIGURATION_INTERRUPT = 1 << 1;
     }
 }
 

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -211,7 +211,7 @@ impl Transport for PciTransport {
     }
 
     fn read_device_features(&mut self) -> u64 {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, device_feature_select, 0);
@@ -223,7 +223,7 @@ impl Transport for PciTransport {
     }
 
     fn write_driver_features(&mut self, driver_features: u64) {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, driver_feature_select, 0);
@@ -238,7 +238,7 @@ impl Transport for PciTransport {
     }
 
     fn max_queue_size(&mut self, queue: u16) -> u32 {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, queue_select, queue);
@@ -247,8 +247,8 @@ impl Transport for PciTransport {
     }
 
     fn notify(&mut self, queue: u16) {
-        // Safe because the common config and notify region pointers are valid and we checked in
-        // get_bar_region that they were aligned.
+        // SAFETY: The common config and notify region pointers are valid and we checked in
+        // `get_bar_region` that they were aligned.
         unsafe {
             volwrite!(self.common_cfg, queue_select, queue);
             // TODO: Consider caching this somewhere (per queue).
@@ -261,14 +261,14 @@ impl Transport for PciTransport {
     }
 
     fn get_status(&self) -> DeviceStatus {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         let status = unsafe { volread!(self.common_cfg, device_status) };
         DeviceStatus::from_bits_truncate(status.into())
     }
 
     fn set_status(&mut self, status: DeviceStatus) {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, device_status, status.bits() as u8);
@@ -291,7 +291,7 @@ impl Transport for PciTransport {
         driver_area: PhysAddr,
         device_area: PhysAddr,
     ) {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, queue_select, queue);
@@ -309,7 +309,7 @@ impl Transport for PciTransport {
     }
 
     fn queue_used(&mut self, queue: u16) -> bool {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         unsafe {
             volwrite!(self.common_cfg, queue_select, queue);
@@ -318,7 +318,7 @@ impl Transport for PciTransport {
     }
 
     fn ack_interrupt(&mut self) -> bool {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
+        // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
         // was aligned.
         // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
         let isr_status = unsafe { self.isr_status.as_ptr().vread() };
@@ -442,8 +442,7 @@ fn get_bar_region<H: Hal, T, C: ConfigurationAccess>(
         return Err(VirtioPciError::BarOffsetOutOfRange);
     }
     let paddr = bar_address as PhysAddr + struct_info.offset as PhysAddr;
-    // Safe because the paddr and size describe a valid MMIO region, at least according to the PCI
-    // bus.
+    // SAFETY: The paddr and size describe a valid MMIO region, at least according to the PCI bus.
     let vaddr = unsafe { H::mmio_phys_to_virt(paddr, struct_info.length as usize) };
     if vaddr.as_ptr() as usize % align_of::<T>() != 0 {
         return Err(VirtioPciError::Misaligned {

--- a/src/transport/pci/bus.rs
+++ b/src/transport/pci/bus.rs
@@ -150,7 +150,7 @@ impl<C: ConfigurationAccess> PciRoot<C> {
 
     /// Enumerates PCI devices on the given bus.
     pub fn enumerate_bus(&self, bus: u8) -> BusDeviceIterator<C> {
-        // Safe because the BusDeviceIterator only reads read-only fields.
+        // SAFETY: The `BusDeviceIterator` only reads read-only fields.
         let configuration_access = unsafe { self.configuration_access.unsafe_clone() };
         BusDeviceIterator {
             configuration_access,
@@ -343,8 +343,8 @@ impl MmioCam {
 impl ConfigurationAccess for MmioCam {
     fn read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
         let address = self.cam.cam_offset(device_function, register_offset);
-        // Safe because both the `mmio_base` and the address offset are properly aligned, and the
-        // resulting pointer is within the MMIO range of the CAM.
+        // SAFETY: Both the `mmio_base` and the address offset are properly aligned,
+        // and the resulting pointer is within the MMIO range of the CAM.
         unsafe {
             // Right shift to convert from byte offset to word offset.
             (self.mmio_base.add((address >> 2) as usize)).read_volatile()
@@ -353,8 +353,8 @@ impl ConfigurationAccess for MmioCam {
 
     fn write_word(&mut self, device_function: DeviceFunction, register_offset: u8, data: u32) {
         let address = self.cam.cam_offset(device_function, register_offset);
-        // Safe because both the `mmio_base` and the address offset are properly aligned, and the
-        // resulting pointer is within the MMIO range of the CAM.
+        // SAFETY: Both the `mmio_base` and the address offset are properly aligned,
+        // and the resulting pointer is within the MMIO range of the CAM.
         unsafe {
             // Right shift to convert from byte offset to word offset.
             (self.mmio_base.add((address >> 2) as usize)).write_volatile(data)

--- a/src/transport/some.rs
+++ b/src/transport/some.rs
@@ -1,7 +1,7 @@
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use super::{mmio::MmioTransport, pci::PciTransport, DeviceStatus, DeviceType, Transport};
-use crate::{PhysAddr, Result};
+use crate::{transport::InterruptStatus, PhysAddr, Result};
 
 /// A wrapper for an arbitrary VirtIO transport, either MMIO or PCI.
 #[derive(Debug)]
@@ -143,7 +143,7 @@ impl Transport for SomeTransport {
         }
     }
 
-    fn ack_interrupt(&mut self) -> bool {
+    fn ack_interrupt(&mut self) -> InterruptStatus {
         match self {
             Self::Mmio(mmio) => mmio.ack_interrupt(),
             Self::Pci(pci) => pci.ack_interrupt(),

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -68,7 +68,7 @@ impl<T: Copy> VolatileWritable<T> for *mut Volatile<T> {
 /// # Usage
 /// ```compile_fail
 /// # use core::ptr::NonNull;
-/// # use virtio_drivers::volatile::{ReadOnly, volread};
+/// # use virtio_drivers_and_devices::volatile::{ReadOnly, volread};
 /// struct MmioDevice {
 ///   field: ReadOnly<u32>,
 /// }
@@ -87,7 +87,7 @@ macro_rules! volread {
 /// # Usage
 /// ```compile_fail
 /// # use core::ptr::NonNull;
-/// # use virtio_drivers::volatile::{WriteOnly, volread};
+/// # use virtio_drivers_and_devices::volatile::{WriteOnly, volread};
 /// struct MmioDevice {
 ///   field: WriteOnly<u32>,
 /// }


### PR DESCRIPTION
Sometimes, it is useful to be able to wrap a `SomeTransport` in an `Arc` in order to have multiple references to it even though it isn't `Clone`.