### PR TITLE
perf: optimize virtio-blk queue size and memory barrier

### DIFF
--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -10,7 +10,7 @@ use log::info;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 const QUEUE: u16 = 0;
-const QUEUE_SIZE: u16 = 16;
+const QUEUE_SIZE: u16 = 256;
 const SUPPORTED_FEATURES: BlkFeature = BlkFeature::RO
     .union(BlkFeature::FLUSH)
     .union(BlkFeature::RING_INDIRECT_DESC)

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -201,8 +201,10 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         }
 
         // Write barrier so that device sees changes to descriptor table and available ring before
-        // change to available index.
-        fence(Ordering::SeqCst);
+        // change to available index. A Release fence is sufficient: it ensures all prior writes
+        // (descriptor table, avail ring entry) are ordered before the subsequent Release store to
+        // avail.idx. This matches Linux's dma_wmb() / virtio_wmb() semantics.
+        fence(Ordering::Release);
 
         // increase head of avail ring
         self.avail_idx = self.avail_idx.wrapping_add(1);


### PR DESCRIPTION
Two performance improvements for the virtio-blk driver.

1. Queue size 16 to 256: matches Linux virtio_blk default, reduces per-request notification overhead.
2. Memory barrier SeqCst to Release: matches Linux dma_wmb semantics. On RISC-V changes fence rw,rw to fence rw,w.

Benchmark on StarryOS riscv64 QEMU TCG 10MB sequential IO:
READ 4K: 35.74 to 42.09 MB/s (+17.8%)
WRITE 4K: 1.11 to 1.15 MB/s (+3.6%)

Test plan: cargo check passes, StarryOS smoke test no regression.