### PR TITLE
Examples: Make network tests more protable

### DIFF
--- a/examples/hexagon/Makefile
+++ b/examples/hexagon/Makefile
@@ -56,7 +56,7 @@ clean:
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -4 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \

--- a/examples/hexagon/Makefile
+++ b/examples/hexagon/Makefile
@@ -56,7 +56,7 @@ clean:
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -N -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \

--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -46,7 +46,7 @@ clean:
 
 qemu-legacy: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -4 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \
@@ -67,7 +67,7 @@ qemu-legacy: kernel $(img)
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -4 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \

--- a/examples/riscv/Makefile
+++ b/examples/riscv/Makefile
@@ -46,7 +46,7 @@ clean:
 
 qemu-legacy: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -N -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \
@@ -67,7 +67,7 @@ qemu-legacy: kernel $(img)
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -N -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
 	qemu-system-$(arch) \
 	  $(QEMU_ARGS) \
 		-machine virt \

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -58,7 +58,7 @@ clean:
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -N -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
 	qemu-system-$(arch) $(QEMU_ARGS)
 
 $(img):

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -58,7 +58,7 @@ clean:
 
 qemu: kernel $(img)
 # Wait a few seconds, then try to open a connection to the VM so it can test its networking.
-	( sleep 4 && echo "hello" | nc localhost 5555 -w 1 -v) &
+	( sleep 4 && echo "hello" | nc localhost 5555 -4 -w 1 -v) &
 	qemu-system-$(arch) $(QEMU_ARGS)
 
 $(img):


### PR DESCRIPTION
Replace `nc -N` with `-w 1` for portability.
The `-N` flag (close on stdin EOF) is not supported by all netcat
implementations. Fedora, Ubuntu, and Debian ship variants that lack it.

Replace `-N` with `-w 1`, which closes the connection 1 second after the
last activity. This achieves the same effect and is supported by both
major netcat variants (GNU netcat and nmap ncat).

In addition, force `nc` to use use of IPv4 since QEMU's user-mode networking only supports that.