### PR TITLE
virtio-gpu: add virgl 3D / blob support with a runtime-gated regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ VirtIO guest drivers in Rust. For **no_std** environment.
 
 ```bash
 cd examples/x86_64
-make qemu
+make qemu          # plain 2D virtio-gpu; the virgl 3D tests are skipped
+make qemu gl=on    # GL-capable virtio-gpu; runs the virgl 3D & blob tests
 ```
+
+`gl=on` attaches a `virtio-gpu-gl-pci` device (with `blob=on`) and needs a QEMU built
+with virglrenderer/OpenGL support. Without it the 3D tests are skipped at runtime
+(`has_virgl()` is false), so hosts without GL are unaffected.
 
 ### [aarch64](./examples/aarch64)
 

--- a/examples/x86_64/Makefile
+++ b/examples/x86_64/Makefile
@@ -5,6 +5,7 @@ kernel := target/$(target)/$(mode)/$(arch)
 img := target/$(target)/$(mode)/img
 accel ?= on
 tcp ?= on
+gl ?= off
 
 sysroot := $(shell rustc --print sysroot)
 objdump := $(shell find $(sysroot) -name llvm-objdump) --arch-name=$(arch)
@@ -20,12 +21,20 @@ else
 	BUILD_ARGS += --no-default-features
 endif
 
+# virgl (3D) testing requires a GL-capable QEMU; default to the plain 2D device
+# so that hosts without GL support can still run the 2D example.
+ifeq ($(gl), on)
+	GPU_DEVICE := -device virtio-gpu-gl-pci,blob=on -display egl-headless
+else
+	GPU_DEVICE := -device virtio-gpu-pci
+endif
+
 QEMU_ARGS += \
 	-machine q35 \
 	-serial mon:stdio \
 	-kernel $(kernel) \
 	-fsdev local,id=fsdev0,path=$(PWD),security_model=none \
-	-device virtio-gpu-pci -vga none \
+	$(GPU_DEVICE) -vga none \
 	-device virtio-blk-pci,drive=x0 -drive file=$(img),if=none,format=raw,id=x0 \
 	-device virtio-9p-pci,fsdev=fsdev0,mount_tag=p9_tmp \
 	-device virtio-rng-pci \

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -11,6 +11,7 @@ mod hal;
 mod heap;
 mod logger;
 mod trap;
+mod virgl;
 
 #[cfg(feature = "tcp")]
 mod tcp;
@@ -195,6 +196,17 @@ fn virtio_9p<T: Transport>(transport: T) {
 
 fn virtio_gpu<T: Transport>(transport: T) {
     let mut gpu = VirtIOGpu::<HalImpl, T>::new(transport).expect("failed to create gpu driver");
+
+    // Run the virgl 3D tests if the host exposed a GL context (`make run gl=on`).
+    // On a plain 2D device the VIRGL feature is not negotiated, so we skip.
+    if gpu.has_virgl() {
+        info!("VIRGL negotiated — running 3D tests");
+        virgl::run(&mut gpu);
+        info!("virtio-gpu 3D (virgl) tests passed");
+    } else {
+        info!("VIRGL not available — skipping 3D tests (use `make run gl=on`)");
+    }
+
     let (width, height) = gpu.resolution().expect("failed to get resolution");
     let width = width as usize;
     let height = height as usize;

--- a/examples/x86_64/src/virgl.rs
+++ b/examples/x86_64/src/virgl.rs
@@ -52,7 +52,7 @@ const HEIGHT: u32 = 256;
 const TRANSFER_SIZE: u32 = WIDTH * HEIGHT * 4;
 /// Blob resource (guest-backed).
 const RESOURCE_ID_BLOB: u32 = 101;
-const BLOB_SIZE: u32 = PAGE_SIZE as u32;
+const BLOB_SIZE: usize = PAGE_SIZE;
 
 /// Number of contiguous pages for `size` bytes.
 const fn pages(size: usize) -> usize {
@@ -264,17 +264,22 @@ pub fn run(gpu: &mut VirtIOGpu<HalImpl, impl Transport>) {
     // ── 11/15: blob resource (feature-gated) ──
     if gpu.has_resource_blob() {
         let (blob_paddr, _blob_vaddr) =
-            HalImpl::dma_alloc(pages(BLOB_SIZE as usize), BufferDirection::Both, false);
-        gpu.resource_create_blob(
-            1,
-            RESOURCE_ID_BLOB,
-            BLOB_MEM_GUEST,
-            0,
-            BLOB_SIZE as u64,
-            0,
-            &[(blob_paddr, BLOB_SIZE)],
-        )
-        .expect("[VIRGL] 11/15 resource_create_blob(GUEST) failed");
+            HalImpl::dma_alloc(pages(BLOB_SIZE), BufferDirection::Both, false);
+        // SAFETY: `blob_paddr` is a dedicated DMA allocation that is valid
+        // device-accessible memory, outlives the blob resource (nothing frees
+        // it before the resource is unref'd), and is not aliased.
+        unsafe {
+            gpu.resource_create_blob(
+                1,
+                RESOURCE_ID_BLOB,
+                BLOB_MEM_GUEST,
+                0,
+                BLOB_SIZE as u64,
+                0,
+                &[(blob_paddr, BLOB_SIZE)],
+            )
+            .expect("[VIRGL] 11/15 resource_create_blob(GUEST) failed");
+        }
         gpu.resource_unref(RESOURCE_ID_BLOB)
             .expect("[VIRGL] 11/15 resource_unref(101) failed");
         info!("[VIRGL] 11/15 resource_create_blob(GUEST) OK");

--- a/examples/x86_64/src/virgl.rs
+++ b/examples/x86_64/src/virgl.rs
@@ -1,0 +1,306 @@
+//! virgl 3D regression test for the virtio-gpu driver.
+//!
+//! Exercises the whole virgl command path: feature negotiation, capset query,
+//! context create/destroy, 3D resource create, attach/detach, host transfers,
+//! fenced command submission and blob resources. Runs only when the VIRGL
+//! feature was negotiated — i.e. the host exposes a GL context (`make run
+//! gl=on` with a GL-capable QEMU). On a plain 2D device the caller skips us.
+
+use super::HalImpl;
+use virtio_drivers::device::gpu::{GpuBox, VirtIOGpu};
+use virtio_drivers::transport::Transport;
+use virtio_drivers::{BufferDirection, Hal, PAGE_SIZE};
+
+// ── pipe / virgl constants (from Gallium/virglrenderer headers) ──────────
+/// Capset id for VIRGL (OpenGL).
+const CAPSET_VIRGL: u32 = 1;
+/// PIPE_TEXTURE_2D
+const PIPE_TEXTURE_2D: u32 = 2;
+/// PIPE_FORMAT_B8G8R8A8_UNORM
+const PIPE_FORMAT_B8G8R8A8_UNORM: u32 = 1;
+/// PIPE_BIND_RENDER_TARGET
+const PIPE_BIND_RENDER_TARGET: u32 = 2;
+/// VIRTIO_GPU_RESOURCE_FLAG_Y_0_TOP
+const RESOURCE_FLAG_Y_0_TOP: u32 = 1;
+/// VIRTIO_GPU_BLOB_MEM_GUEST — guest-backed blob (`resource_create_blob`).
+///
+/// We exercise the guest-backed path rather than `BLOB_MEM_HOST3D`: a HOST3D
+/// blob requires the context to already contain a resource registered under
+/// the given `blob_id` (virglrenderer `vrend_get_blob_pipe`), which is only
+/// created by a preceding virgl `VIRGL_PIPE_RES_CREATE` submit — something
+/// `resource_create_blob` alone cannot express. A GUEST blob is the API's
+/// primary use and works with just a DMA region.
+const BLOB_MEM_GUEST: u32 = 0x1;
+/// VIRGL_CCMD_CREATE_OBJECT (enum `virgl_context_cmd`, value 1)
+const VIRGL_CCMD_CREATE_OBJECT: u32 = 1;
+/// VIRGL_CCMD_SET_FRAMEBUFFER_STATE (enum `virgl_context_cmd`, value 5)
+const VIRGL_CCMD_SET_FRAMEBUFFER_STATE: u32 = 5;
+/// VIRGL_CCMD_CLEAR (enum `virgl_context_cmd`, value 7)
+const VIRGL_CCMD_CLEAR: u32 = 7;
+/// VIRGL_OBJECT_SURFACE (enum `virgl_object_type`, value 8)
+const VIRGL_OBJECT_SURFACE: u32 = 8;
+/// PIPE_CLEAR_COLOR
+const PIPE_CLEAR_COLOR: u32 = 0x1;
+
+/// 256×256 render target.
+const RESOURCE_ID: u32 = 100;
+/// Surface handle bound to RESOURCE_ID as the framebuffer color attachment.
+const SURFACE_ID: u32 = 200;
+const WIDTH: u32 = 256;
+const HEIGHT: u32 = 256;
+/// B8G8R8A8 backing for the render target (WIDTH*HEIGHT*4 bytes).
+const TRANSFER_SIZE: u32 = WIDTH * HEIGHT * 4;
+/// Blob resource (guest-backed).
+const RESOURCE_ID_BLOB: u32 = 101;
+const BLOB_SIZE: u32 = PAGE_SIZE as u32;
+
+/// Number of contiguous pages for `size` bytes.
+const fn pages(size: usize) -> usize {
+    (size + PAGE_SIZE - 1) / PAGE_SIZE
+}
+
+/// Build a virgl CLEAR command buffer (9 dwords = 36 bytes).
+///
+/// Wire format (little-endian, `len` counts the dwords *after* the header):
+///   dword[0] = (len << 16) | VIRGL_CCMD_CLEAR   (len = 8)
+///   dword[1] = buffers bitmask (1=color, 2=depth, 4=stencil)
+///   dword[2..5] = RGBA clear color as f32
+///   dword[6..7] = depth clear value as f64 (double)
+///   dword[8] = stencil clear value as u32
+fn build_clear_cmd(
+    buffers: u32,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+    depth: f64,
+    stencil: u32,
+) -> [u8; 36] {
+    let mut cmd = [0u8; 36];
+    cmd[0..4].copy_from_slice(&((8u32 << 16) | VIRGL_CCMD_CLEAR).to_le_bytes());
+    cmd[4..8].copy_from_slice(&buffers.to_le_bytes());
+    cmd[8..12].copy_from_slice(&r.to_bits().to_le_bytes());
+    cmd[12..16].copy_from_slice(&g.to_bits().to_le_bytes());
+    cmd[16..20].copy_from_slice(&b.to_bits().to_le_bytes());
+    cmd[20..24].copy_from_slice(&a.to_bits().to_le_bytes());
+    cmd[24..32].copy_from_slice(&depth.to_bits().to_le_bytes());
+    cmd[32..36].copy_from_slice(&stencil.to_le_bytes());
+    cmd
+}
+
+/// Build a render command stream (19 dwords = 76 bytes):
+/// CREATE_OBJECT(surface) → SET_FRAMEBUFFER_STATE → CLEAR.
+///
+/// A bare CLEAR on a context with no bound surface fails in virglrenderer with
+/// GL_INVALID_FRAMEBUFFER_OPERATION (`vrend_clear` runs `glClear` on the current
+/// framebuffer), so the stream first creates a surface over the render target and
+/// binds it as the single color attachment. Wire format per virgl_protocol.h
+/// (`len` counts the dwords *after* the header, host advances `buf_offset += len+1`):
+///   dword[0]  = (len=5 << 16) | (obj=SURFACE << 8) | cmd=CREATE_OBJECT
+///   dword[1]  = surface handle
+///   dword[2]  = res handle (the render target)
+///   dword[3]  = format (PIPE_FORMAT_B8G8R8A8_UNORM)
+///   dword[4]  = texture level
+///   dword[5]  = layers (first=0, last=0 → 1 layer)
+///   dword[6]  = (len=3 << 16) | cmd=SET_FRAMEBUFFER_STATE
+///   dword[7]  = nr_cbufs = 1
+///   dword[8]  = zsurf handle (0 = none)
+///   dword[9]  = cbuf0 handle (the surface)
+///   dword[10..18] = CLEAR (see `build_clear_cmd`)
+fn build_render_cmd(
+    buffers: u32,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+    depth: f64,
+    stencil: u32,
+) -> [u8; 76] {
+    let mut cmd = [0u8; 76];
+    // ── CREATE_OBJECT surface (6 dwords) ──
+    cmd[0..4].copy_from_slice(
+        &((5u32 << 16) | (VIRGL_OBJECT_SURFACE << 8) | VIRGL_CCMD_CREATE_OBJECT).to_le_bytes(),
+    );
+    cmd[4..8].copy_from_slice(&SURFACE_ID.to_le_bytes());
+    cmd[8..12].copy_from_slice(&RESOURCE_ID.to_le_bytes());
+    cmd[12..16].copy_from_slice(&PIPE_FORMAT_B8G8R8A8_UNORM.to_le_bytes());
+    cmd[16..20].copy_from_slice(&0u32.to_le_bytes());
+    cmd[20..24].copy_from_slice(&0u32.to_le_bytes());
+    // ── SET_FRAMEBUFFER_STATE (4 dwords) ──
+    cmd[24..28].copy_from_slice(&((3u32 << 16) | VIRGL_CCMD_SET_FRAMEBUFFER_STATE).to_le_bytes());
+    cmd[28..32].copy_from_slice(&1u32.to_le_bytes());
+    cmd[32..36].copy_from_slice(&0u32.to_le_bytes());
+    cmd[36..40].copy_from_slice(&SURFACE_ID.to_le_bytes());
+    // ── CLEAR (9 dwords) ──
+    cmd[40..76].copy_from_slice(&build_clear_cmd(buffers, r, g, b, a, depth, stencil));
+    cmd
+}
+
+/// Run the virgl 3D regression tests. Panics on the first failing step.
+pub fn run(gpu: &mut VirtIOGpu<HalImpl, impl Transport>) {
+    // ── 01/15: VIRGL feature negotiated ──
+    assert!(gpu.has_virgl(), "[VIRGL] 01/15 has_virgl() == false");
+    info!("[VIRGL] 01/15 has_virgl OK");
+
+    // ── 02/15: capset info ──
+    let info = gpu
+        .get_capset_info(0)
+        .expect("[VIRGL] 02/15 get_capset_info(0) failed");
+    assert_eq!(
+        info.capset_id, CAPSET_VIRGL,
+        "[VIRGL] 02/15 wrong capset id"
+    );
+    assert!(
+        info.capset_max_version >= 1,
+        "[VIRGL] 02/15 max_version < 1"
+    );
+    assert!(info.capset_max_size > 0, "[VIRGL] 02/15 max_size == 0");
+    info!(
+        "[VIRGL] 02/15 capset id={} max_ver={} max_size={}",
+        info.capset_id, info.capset_max_version, info.capset_max_size
+    );
+
+    // ── 03/15: capset data ──
+    let capset = gpu
+        .get_capset(info.capset_id, 0, info.capset_max_size)
+        .expect("[VIRGL] 03/15 get_capset failed");
+    assert_eq!(
+        capset.len(),
+        info.capset_max_size as usize,
+        "[VIRGL] 03/15 capset len != max_size"
+    );
+    info!("[VIRGL] 03/15 capset data {} bytes OK", capset.len());
+
+    // ── 04/15: create context ──
+    gpu.ctx_create(1, "virgl", CAPSET_VIRGL)
+        .expect("[VIRGL] 04/15 ctx_create(1, \"virgl\") failed");
+    info!("[VIRGL] 04/15 ctx_create OK");
+
+    // ── 05/15: create a 256×256 render target ──
+    gpu.resource_create_3d(
+        1,
+        RESOURCE_ID,
+        PIPE_TEXTURE_2D,
+        PIPE_FORMAT_B8G8R8A8_UNORM,
+        PIPE_BIND_RENDER_TARGET,
+        WIDTH,
+        HEIGHT,
+        1,
+        1,
+        0,
+        0,
+        RESOURCE_FLAG_Y_0_TOP,
+    )
+    .expect("[VIRGL] 05/15 resource_create_3d(100) failed");
+    info!("[VIRGL] 05/15 resource_create_3d(100, 256×256 T2D RT) OK");
+
+    // ── 06/15: attach resource to context ──
+    gpu.ctx_attach_resource(1, RESOURCE_ID)
+        .expect("[VIRGL] 06/15 ctx_attach_resource(1, 100) failed");
+    info!("[VIRGL] 06/15 ctx_attach_resource OK");
+
+    // ── 07/15: attach guest backing for the transfers ──
+    // The host transfers only happen if the resource carries guest backing
+    // (`res->iov` in virglrenderer) or the transfer itself supplies iovecs —
+    // QEMU's virgl path does neither by itself, so without this step the
+    // transfer commands are silently rejected with "Illegal resource".
+    let (transfer_paddr, _transfer_vaddr) =
+        HalImpl::dma_alloc(pages(TRANSFER_SIZE as usize), BufferDirection::Both, false);
+    gpu.resource_attach_backing(RESOURCE_ID, transfer_paddr, TRANSFER_SIZE)
+        .expect("[VIRGL] 07/15 resource_attach_backing(100) failed");
+    info!("[VIRGL] 07/15 resource_attach_backing OK");
+
+    // ── 08/15: upload into the resource ──
+    gpu.transfer_to_host_3d(
+        1,
+        RESOURCE_ID,
+        GpuBox {
+            x: 0,
+            y: 0,
+            z: 0,
+            w: WIDTH,
+            h: HEIGHT,
+            d: 1,
+        },
+        0,
+        0,
+        1024,
+        0,
+    )
+    .expect("[VIRGL] 08/15 transfer_to_host_3d(100) failed");
+    info!("[VIRGL] 08/15 transfer_to_host_3d OK");
+
+    // ── 09/15: download command (host writes back into the same backing) ──
+    gpu.transfer_from_host_3d(
+        1,
+        RESOURCE_ID,
+        GpuBox {
+            x: 0,
+            y: 0,
+            z: 0,
+            w: WIDTH,
+            h: HEIGHT,
+            d: 1,
+        },
+        0,
+        0,
+        1024,
+        0,
+    )
+    .expect("[VIRGL] 09/15 transfer_from_host_3d(100) failed");
+    info!("[VIRGL] 09/15 transfer_from_host_3d OK");
+
+    // ── 10/15: submit a fenced CLEAR against a bound surface ──
+    let render_cmd = build_render_cmd(PIPE_CLEAR_COLOR, 0.2, 0.4, 0.6, 0.8, 1.0, 0);
+    // The stream must be dword-aligned and length-consistent with each command
+    // header: (5+1) + (3+1) + (8+1) = 19 dwords.
+    assert_eq!(render_cmd.len(), 19 * 4, "[VIRGL] 10/15 render stream size");
+    gpu.submit_3d(1, 1, &render_cmd)
+        .expect("[VIRGL] 10/15 submit_3d(CREATE_SURFACE+FBO+CLEAR) failed");
+    // The fence response is sent after the host flushes GL, so rendering is
+    // done once `submit_3d` returns.
+    info!("[VIRGL] 10/15 submit_3d(CREATE_SURFACE+FBO+CLEAR) OK");
+
+    // ── 11/15: blob resource (feature-gated) ──
+    if gpu.has_resource_blob() {
+        let (blob_paddr, _blob_vaddr) =
+            HalImpl::dma_alloc(pages(BLOB_SIZE as usize), BufferDirection::Both, false);
+        gpu.resource_create_blob(
+            1,
+            RESOURCE_ID_BLOB,
+            BLOB_MEM_GUEST,
+            0,
+            BLOB_SIZE as u64,
+            0,
+            &[(blob_paddr, BLOB_SIZE)],
+        )
+        .expect("[VIRGL] 11/15 resource_create_blob(GUEST) failed");
+        gpu.resource_unref(RESOURCE_ID_BLOB)
+            .expect("[VIRGL] 11/15 resource_unref(101) failed");
+        info!("[VIRGL] 11/15 resource_create_blob(GUEST) OK");
+    } else {
+        info!("[VIRGL] 11/15 resource_create_blob SKIP (no RESOURCE_BLOB feature)");
+    }
+
+    // ── 12/15: detach from context ──
+    gpu.ctx_detach_resource(1, RESOURCE_ID)
+        .expect("[VIRGL] 12/15 ctx_detach_resource(1, 100) failed");
+    info!("[VIRGL] 12/15 ctx_detach_resource OK");
+
+    // ── 13/15: release the backing mapping ──
+    gpu.resource_detach_backing(RESOURCE_ID)
+        .expect("[VIRGL] 13/15 resource_detach_backing(100) failed");
+    info!("[VIRGL] 13/15 resource_detach_backing OK");
+
+    // ── 14/15: release resource ──
+    gpu.resource_unref(RESOURCE_ID)
+        .expect("[VIRGL] 14/15 resource_unref(100) failed");
+    info!("[VIRGL] 14/15 resource_unref OK");
+
+    // ── 15/15: destroy context ──
+    gpu.ctx_destroy(1)
+        .expect("[VIRGL] 15/15 ctx_destroy(1) failed");
+    info!("[VIRGL] 15/15 ctx_destroy OK");
+
+    info!("[VIRGL] === ALL 15 STEPS PASSED ===");
+}

--- a/src/device/gpu/mod.rs
+++ b/src/device/gpu/mod.rs
@@ -5,7 +5,7 @@ mod edid;
 pub use self::edid::Edid;
 
 use crate::config::{ReadOnly, WriteOnly, read_config};
-use crate::hal::{BufferDirection, Dma, Hal};
+use crate::hal::{BufferDirection, Dma, Hal, PhysAddr};
 use crate::queue::VirtQueue;
 use crate::transport::{InterruptStatus, Transport};
 use crate::{Error, PAGE_SIZE, Result, pages};
@@ -52,8 +52,6 @@ pub struct VirtIOGpu<H: Hal, T: Transport> {
     control_queue: VirtQueue<H, { QUEUE_SIZE as usize }>,
     /// Queue for sending cursor commands.
     cursor_queue: VirtQueue<H, { QUEUE_SIZE as usize }>,
-    /// Send buffer for queue.
-    queue_buf_send: Box<[u8]>,
     /// Recv buffer for queue.
     queue_buf_recv: Box<[u8]>,
     /// Whether EDID feature was negotiated.
@@ -98,7 +96,6 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             access_platform,
         )?;
 
-        let queue_buf_send = FromZeros::new_box_zeroed_with_elems(PAGE_SIZE).unwrap();
         let queue_buf_recv = FromZeros::new_box_zeroed_with_elems(PAGE_SIZE).unwrap();
 
         transport.finish_init();
@@ -119,7 +116,6 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             rect: None,
             control_queue,
             cursor_queue,
-            queue_buf_send,
             queue_buf_recv,
             has_edid,
             access_platform,
@@ -289,27 +285,34 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     }
 
     /// Send a request to the device and block for a response.
+    ///
+    /// The call is synchronous: `req` lives on the stack until the device has
+    /// consumed it (the used ring entry is popped below), so `req.as_bytes()`
+    /// can be handed to the queue directly without copying.
     fn request<Req: IntoBytes + Immutable, Rsp: FromBytes>(&mut self, req: Req) -> Result<Rsp> {
-        req.write_to_prefix(&mut self.queue_buf_send).unwrap();
-        // Only hand the device the bytes actually written, NOT the whole
-        // 4096-byte queue_buf_send.  The device parses the command strictly
-        // by the header's size field; trailing zero padding would shift
-        // every subsequent scatter-gather buffer (e.g. SUBMIT_3D payload).
-        let send = &self.queue_buf_send[..size_of::<Req>()];
-        self.control_queue.add_notify_wait_pop(
-            &[send],
+        Ok(self.request_with_len(req)?.0)
+    }
+
+    /// Like `request`, but also returns how many bytes the device wrote to the
+    /// receive buffer (from the used ring entry). Needed by `get_capset` to
+    /// slice the trailing capset data precisely.
+    fn request_with_len<Req: IntoBytes + Immutable, Rsp: FromBytes>(
+        &mut self,
+        req: Req,
+    ) -> Result<(Rsp, usize)> {
+        let used_len = self.control_queue.add_notify_wait_pop(
+            &[req.as_bytes()],
             &mut [&mut self.queue_buf_recv],
             &mut self.transport,
-        )?;
-        Ok(Rsp::read_from_prefix(&self.queue_buf_recv).unwrap().0)
+        )? as usize;
+        let rsp = Rsp::read_from_prefix(&self.queue_buf_recv).unwrap().0;
+        Ok((rsp, used_len))
     }
 
     /// Send a mouse cursor operation request to the device and block for a response.
     fn cursor_request<Req: IntoBytes + Immutable>(&mut self, req: Req) -> Result {
-        req.write_to_prefix(&mut self.queue_buf_send).unwrap();
-        let send = &self.queue_buf_send[..size_of::<Req>()];
         self.cursor_queue
-            .add_notify_wait_pop(&[send], &mut [], &mut self.transport)?;
+            .add_notify_wait_pop(&[req.as_bytes()], &mut [], &mut self.transport)?;
         Ok(())
     }
 
@@ -321,17 +324,15 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         req: Req,
         data: &[u8],
     ) -> Result<Rsp> {
-        req.write_to_prefix(&mut self.queue_buf_send).unwrap();
-        let send = &self.queue_buf_send[..size_of::<Req>()];
         if data.is_empty() {
             self.control_queue.add_notify_wait_pop(
-                &[send],
+                &[req.as_bytes()],
                 &mut [&mut self.queue_buf_recv],
                 &mut self.transport,
             )?;
         } else {
             self.control_queue.add_notify_wait_pop(
-                &[send, data],
+                &[req.as_bytes(), data],
                 &mut [&mut self.queue_buf_recv],
                 &mut self.transport,
             )?;
@@ -348,8 +349,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
 
     /// Create a 2D resource with the given dimensions.
     ///
-    /// Format is always `B8G8R8A8UNORM`. Use [`resource_attach_backing`]
-    /// to give the resource guest-visible memory, and [`set_scanout`] to
+    /// Format is always `B8G8R8A8UNORM`. Use [`VirtIOGpu::resource_attach_backing`]
+    /// to give the resource guest-visible memory, and [`VirtIOGpu::set_scanout`] to
     /// bind it as the display output.
     pub fn resource_create_2d(&mut self, resource_id: u32, width: u32, height: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceCreate2D {
@@ -401,8 +402,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     /// Attach a single DMA-backed memory region to a resource.
     ///
     /// The host uses `paddr` to read/write guest memory for the resource.
-    /// This must be called after [`resource_create_2d`] and before any
-    /// [`transfer_to_host_2d`] or [`set_scanout`].
+    /// This must be called after [`VirtIOGpu::resource_create_2d`] and before any
+    /// [`VirtIOGpu::transfer_to_host_2d`] or [`VirtIOGpu::set_scanout`].
     pub fn resource_attach_backing(&mut self, resource_id: u32, paddr: u64, length: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceAttachBacking {
             header: CtrlHeader::with_type(Command::RESOURCE_ATTACH_BACKING),
@@ -417,7 +418,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
 
     /// Detach the backing memory from a resource.
     ///
-    /// Call this before [`resource_unref`] to release the host's mapping
+    /// Call this before [`VirtIOGpu::resource_unref`] to release the host's mapping
     /// of the guest memory region.
     pub fn resource_detach_backing(&mut self, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceDetachBacking {
@@ -524,19 +525,18 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         if size as usize > self.queue_buf_recv.len() - size_of::<CtrlHeader>() {
             return Err(Error::IoError);
         }
-        let _: CtrlHeader = self.request(CmdGetCapset {
+        // The response is a CtrlHeader (24 bytes) followed by the capset data,
+        // all written back into queue_buf_recv. `size` is only an upper bound:
+        // slice by the bytes the device actually wrote (`used_len`) so no
+        // stale receive-buffer bytes leak into the returned blob.
+        let (hdr, used_len): (CtrlHeader, usize) = self.request_with_len(CmdGetCapset {
             header: CtrlHeader::with_type(Command::GET_CAPSET),
             capset_id,
             capset_version: version,
         })?;
-        // The response is a CtrlHeader (24 bytes) followed by `size` bytes of
-        // capset data, both placed back in queue_buf_recv.
-        let hdr = CtrlHeader::read_from_prefix(&self.queue_buf_recv)
-            .unwrap()
-            .0;
         hdr.check_type(Command::OK_CAPSET)?;
         let start = size_of::<CtrlHeader>();
-        let end = start + size as usize;
+        let end = used_len.clamp(start, start + size as usize);
         Ok(self.queue_buf_recv[start..end].to_vec())
     }
 
@@ -549,17 +549,18 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     /// Linux: `vfpriv->context_init` → `cmd_p->context_init` in the wire command.
     pub fn ctx_create(&mut self, ctx_id: u32, name: &str, context_init: u32) -> Result {
         self.require_virgl()?;
-        let mut debug_name = [0u8; 64];
+        let mut cmd = CmdCtxCreate {
+            header: CtrlHeader::with_type_and_ctx(Command::CTX_CREATE, ctx_id),
+            nlen: 0,
+            context_init,
+            debug_name: [0u8; 64],
+        };
         let bytes = name.as_bytes();
         let nlen = bytes.len().min(64);
-        debug_name[..nlen].copy_from_slice(&bytes[..nlen]);
+        cmd.debug_name[..nlen].copy_from_slice(&bytes[..nlen]);
+        cmd.nlen = nlen as u32;
 
-        let rsp: CtrlHeader = self.request(CmdCtxCreate {
-            header: CtrlHeader::with_type_and_ctx(Command::CTX_CREATE, ctx_id),
-            nlen: nlen as u32,
-            context_init,
-            debug_name,
-        })?;
+        let rsp: CtrlHeader = self.request(cmd)?;
         rsp.check_type(Command::OK_NODATA)
     }
 
@@ -697,7 +698,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // The virgl command stream is a sequence of 32-bit dwords; the host
         // passes `size / 4` dwords to `virgl_renderer_submit_cmd`, so a length
         // that is not a multiple of 4 would be silently truncated.
-        if cmds.len() % 4 != 0 {
+        if !cmds.len().is_multiple_of(4) {
             return Err(Error::InvalidParam);
         }
         let size = u32::try_from(cmds.len()).map_err(|_| Error::IoError)?;
@@ -714,21 +715,35 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
 
     /// Create a blob resource (host-visible memory / dma-buf sharing).
     ///
-    /// Requires `VIRTIO_GPU_F_RESOURCE_BLOB` (see [`has_resource_blob`]).
+    /// Requires `VIRTIO_GPU_F_RESOURCE_BLOB` (see [`VirtIOGpu::has_resource_blob`]).
     ///
     /// - `blob_mem`: `VIRTIO_GPU_BLOB_MEM_GUEST (0x1)`, `HOST3D (0x2)` or
     ///   `HOST3D_GUEST (0x3)`.
     /// - `blob_flags`: `VIRTIO_GPU_BLOB_FLAG_USE_MAPPABLE (0x1)` etc.
     /// - `size`: resource size in bytes.
-    /// - `blob_id`: opaque host-side id (0 unless assigning one).
-    /// - `mem_entries`: guest backing `(addr, len)` pairs, only for GUEST /
+    /// - `blob_id`: for HOST3D blobs, the id of a host-side resource already
+    ///   created on this context via virgl (a bare `resource_create_blob`
+    ///   cannot create it); for GUEST/HOST3D_GUEST blobs, 0 unless assigning one.
+    /// - `mem_entries`: guest backing `(PhysAddr, len)` pairs, only for GUEST /
     ///   HOST3D_GUEST. **HOST3D must pass an empty slice** — QEMU ignores
     ///   backing entries for HOST3D blobs, and virglrenderer rejects blobs
     ///   with a nonzero `num_iovs`.
     ///
+    /// # Safety
+    ///
+    /// For GUEST and HOST3D_GUEST blobs the device reads/writes the guest
+    /// memory at the physical addresses in `mem_entries`. The caller must
+    /// guarantee that every range is valid, device-accessible memory and
+    /// stays allocated and free of concurrent access (no aliasing/UB) for
+    /// as long as the blob resource exists — i.e. until the matching
+    /// [`VirtIOGpu::resource_unref`]. The ranges must also cover `size` bytes
+    /// in total: a blob larger than its backing lets the device access guest
+    /// memory past the end of the provided ranges.
+    ///
     /// Mirrors Linux `virtio_gpu_cmd_resource_create_blob` (`virtgpu_vq.c`).
     /// Responds with OK_NODATA.
-    pub fn resource_create_blob(
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn resource_create_blob(
         &mut self,
         ctx_id: u32,
         resource_id: u32,
@@ -736,7 +751,7 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         blob_flags: u32,
         size: u64,
         blob_id: u64,
-        mem_entries: &[(u64, u32)],
+        mem_entries: &[(PhysAddr, usize)],
     ) -> Result {
         self.require_virgl()?;
         if !self.has_resource_blob {
@@ -745,10 +760,11 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         let nr_entries = u32::try_from(mem_entries.len()).map_err(|_| Error::IoError)?;
         let mut data = Vec::with_capacity(mem_entries.len() * core::mem::size_of::<MemEntry>());
         for (addr, len) in mem_entries {
+            let length = u32::try_from(*len).map_err(|_| Error::InvalidParam)?;
             data.extend_from_slice(
                 MemEntry {
                     addr: *addr,
-                    length: *len,
+                    length,
                     padding: 0,
                 }
                 .as_bytes(),

--- a/src/device/gpu/mod.rs
+++ b/src/device/gpu/mod.rs
@@ -12,15 +12,27 @@ use crate::{Error, PAGE_SIZE, Result, pages};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use bitflags::bitflags;
+use core::mem::size_of;
 use log::info;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
-const QUEUE_SIZE: u16 = 2;
+/// Number of descriptors per virtqueue (const generic bound on `VirtQueue`).
+///
+/// `submit_3d` drives a 3-buffer command — the `CtrlHeader` + the virgl command
+/// stream + the response — and `VirtQueue::add` requires the total number of
+/// in/out buffers to fit inside `SIZE` even when `RING_INDIRECT_DESC` is used
+/// (they all go into one indirect list before occupying a single queue slot).
+/// A depth of 16 is the smallest power of two that comfortably covers that and
+/// any future multi-resource submit while keeping descriptor-table memory small.
+const QUEUE_SIZE: u16 = 16;
 const SUPPORTED_FEATURES: Features = Features::RING_EVENT_IDX
     .union(Features::RING_INDIRECT_DESC)
     .union(Features::VERSION_1)
     .union(Features::ACCESS_PLATFORM)
-    .union(Features::EDID);
+    .union(Features::EDID)
+    .union(Features::VIRGL)
+    .union(Features::CONTEXT_INIT)
+    .union(Features::RESOURCE_BLOB);
 
 /// A virtio based graphics adapter.
 ///
@@ -48,6 +60,11 @@ pub struct VirtIOGpu<H: Hal, T: Transport> {
     has_edid: bool,
     /// Whether `VIRTIO_F_ACCESS_PLATFORM` was negotiated.
     access_platform: bool,
+    /// Whether VIRGL (3D) feature was negotiated.
+    has_virgl: bool,
+    /// Whether `VIRTIO_GPU_F_RESOURCE_BLOB` was negotiated (blob resources,
+    /// dma-buf sharing, host-visible memory).
+    has_resource_blob: bool,
 }
 
 impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
@@ -58,9 +75,10 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // read configuration space
         let events_read = read_config!(transport, Config, events_read)?;
         let num_scanouts = read_config!(transport, Config, num_scanouts)?;
+        let num_capsets = read_config!(transport, Config, num_capsets)?;
         info!(
-            "events_read: {:#x}, num_scanouts: {:#x}",
-            events_read, num_scanouts
+            "events_read: {:#x}, num_scanouts: {:#x}, num_capsets: {:#x}",
+            events_read, num_scanouts, num_capsets
         );
 
         let access_platform = negotiated_features.contains(Features::ACCESS_PLATFORM);
@@ -86,6 +104,13 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         transport.finish_init();
 
         let has_edid = negotiated_features.contains(Features::EDID);
+        let has_virgl = negotiated_features.contains(Features::VIRGL);
+        let has_resource_blob = negotiated_features.contains(Features::RESOURCE_BLOB);
+
+        info!(
+            "GPU features: negotiated={:?}, has_virgl={}, has_edid={}, has_resource_blob={}",
+            negotiated_features, has_virgl, has_edid, has_resource_blob
+        );
 
         Ok(VirtIOGpu {
             transport,
@@ -98,6 +123,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             queue_buf_recv,
             has_edid,
             access_platform,
+            has_virgl,
+            has_resource_blob,
         })
     }
 
@@ -264,8 +291,13 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     /// Send a request to the device and block for a response.
     fn request<Req: IntoBytes + Immutable, Rsp: FromBytes>(&mut self, req: Req) -> Result<Rsp> {
         req.write_to_prefix(&mut self.queue_buf_send).unwrap();
+        // Only hand the device the bytes actually written, NOT the whole
+        // 4096-byte queue_buf_send.  The device parses the command strictly
+        // by the header's size field; trailing zero padding would shift
+        // every subsequent scatter-gather buffer (e.g. SUBMIT_3D payload).
+        let send = &self.queue_buf_send[..size_of::<Req>()];
         self.control_queue.add_notify_wait_pop(
-            &[&self.queue_buf_send],
+            &[send],
             &mut [&mut self.queue_buf_recv],
             &mut self.transport,
         )?;
@@ -275,12 +307,36 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     /// Send a mouse cursor operation request to the device and block for a response.
     fn cursor_request<Req: IntoBytes + Immutable>(&mut self, req: Req) -> Result {
         req.write_to_prefix(&mut self.queue_buf_send).unwrap();
-        self.cursor_queue.add_notify_wait_pop(
-            &[&self.queue_buf_send],
-            &mut [],
-            &mut self.transport,
-        )?;
+        let send = &self.queue_buf_send[..size_of::<Req>()];
+        self.cursor_queue
+            .add_notify_wait_pop(&[send], &mut [], &mut self.transport)?;
         Ok(())
+    }
+
+    /// Send a request with additional data (as a second device-readable buffer)
+    /// and block for a response. Used by SUBMIT_3D where the virgl command stream
+    /// is sent as a separate scatter-gather buffer alongside the CtrlHeader.
+    fn request_with_data<Req: IntoBytes + Immutable, Rsp: FromBytes>(
+        &mut self,
+        req: Req,
+        data: &[u8],
+    ) -> Result<Rsp> {
+        req.write_to_prefix(&mut self.queue_buf_send).unwrap();
+        let send = &self.queue_buf_send[..size_of::<Req>()];
+        if data.is_empty() {
+            self.control_queue.add_notify_wait_pop(
+                &[send],
+                &mut [&mut self.queue_buf_recv],
+                &mut self.transport,
+            )?;
+        } else {
+            self.control_queue.add_notify_wait_pop(
+                &[send, data],
+                &mut [&mut self.queue_buf_recv],
+                &mut self.transport,
+            )?;
+        }
+        Ok(Rsp::read_from_prefix(&self.queue_buf_recv).unwrap().0)
     }
 
     fn get_display_info(&mut self) -> Result<RespDisplayInfo> {
@@ -290,7 +346,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         Ok(info)
     }
 
-    fn resource_create_2d(&mut self, resource_id: u32, width: u32, height: u32) -> Result {
+    /// Create a 2D resource with the given dimensions.
+    ///
+    /// Format is always `B8G8R8A8UNORM`. Use [`resource_attach_backing`]
+    /// to give the resource guest-visible memory, and [`set_scanout`] to
+    /// bind it as the display output.
+    pub fn resource_create_2d(&mut self, resource_id: u32, width: u32, height: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceCreate2D {
             header: CtrlHeader::with_type(Command::RESOURCE_CREATE_2D),
             resource_id,
@@ -301,7 +362,9 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn set_scanout(&mut self, rect: Rect, scanout_id: u32, resource_id: u32) -> Result {
+    /// Bind a resource as the scanout (display output) for the given scanout ID.
+    /// The `rect` specifies the display area.
+    pub fn set_scanout(&mut self, rect: Rect, scanout_id: u32, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(SetScanout {
             header: CtrlHeader::with_type(Command::SET_SCANOUT),
             rect,
@@ -311,7 +374,9 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn resource_flush(&mut self, rect: Rect, resource_id: u32) -> Result {
+    /// Flush a resource's contents to the display. The `rect` specifies the
+    /// area to refresh.
+    pub fn resource_flush(&mut self, rect: Rect, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceFlush {
             header: CtrlHeader::with_type(Command::RESOURCE_FLUSH),
             rect,
@@ -321,7 +386,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn transfer_to_host_2d(&mut self, rect: Rect, offset: u64, resource_id: u32) -> Result {
+    /// Transfer data from guest to host for a 2D resource within the given rectangle.
+    pub fn transfer_to_host_2d(&mut self, rect: Rect, offset: u64, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(TransferToHost2D {
             header: CtrlHeader::with_type(Command::TRANSFER_TO_HOST_2D),
             rect,
@@ -332,7 +398,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn resource_attach_backing(&mut self, resource_id: u32, paddr: u64, length: u32) -> Result {
+    /// Attach a single DMA-backed memory region to a resource.
+    ///
+    /// The host uses `paddr` to read/write guest memory for the resource.
+    /// This must be called after [`resource_create_2d`] and before any
+    /// [`transfer_to_host_2d`] or [`set_scanout`].
+    pub fn resource_attach_backing(&mut self, resource_id: u32, paddr: u64, length: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceAttachBacking {
             header: CtrlHeader::with_type(Command::RESOURCE_ATTACH_BACKING),
             resource_id,
@@ -344,7 +415,11 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn resource_detach_backing(&mut self, resource_id: u32) -> Result {
+    /// Detach the backing memory from a resource.
+    ///
+    /// Call this before [`resource_unref`] to release the host's mapping
+    /// of the guest memory region.
+    pub fn resource_detach_backing(&mut self, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceDetachBacking {
             header: CtrlHeader::with_type(Command::RESOURCE_DETACH_BACKING),
             resource_id,
@@ -353,7 +428,12 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         rsp.check_type(Command::OK_NODATA)
     }
 
-    fn resource_unref(&mut self, resource_id: u32) -> Result {
+    /// Unreference a resource by its ID.
+    ///
+    /// This releases the host-side resource and is the only way to destroy
+    /// a 3D resource (there is no RESOURCE_DESTROY_3D command — the protocol
+    /// uses a single RESOURCE_UNREF for both 2D and 3D resources).
+    pub fn resource_unref(&mut self, resource_id: u32) -> Result {
         let rsp: CtrlHeader = self.request(ResourceUnref {
             header: CtrlHeader::with_type(Command::RESOURCE_UNREF),
             resource_id,
@@ -391,6 +471,303 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
             _padding: 0,
         })
     }
+
+    // ------------------------------------------------------------------
+    // Public 3D (virgl) API — only valid when `has_virgl` returns true.
+    // These map to VirtIO-GPU spec §5.7.5, Table 5.7.5.2.
+    // ------------------------------------------------------------------
+
+    /// Whether the VIRGL (3D acceleration) feature was successfully negotiated.
+    pub fn has_virgl(&self) -> bool {
+        self.has_virgl
+    }
+
+    /// Whether `VIRTIO_GPU_F_RESOURCE_BLOB` was negotiated. Blob resources are
+    /// required for host-visible memory and dma-buf sharing (PRIME).
+    pub fn has_resource_blob(&self) -> bool {
+        self.has_resource_blob
+    }
+
+    /// Returns `Err` if the VIRGL feature was not negotiated. All 3D commands
+    /// are undefined without it and the host would reject them anyway.
+    fn require_virgl(&self) -> Result {
+        if self.has_virgl {
+            Ok(())
+        } else {
+            Err(Error::IoError)
+        }
+    }
+
+    /// Query capset information by index (0-based).
+    ///
+    /// The returned `RespCapsetInfo` contains the capset ID, max version, and max
+    /// data size. Callers should then use `get_capset` to retrieve the actual
+    /// capset data.
+    pub fn get_capset_info(&mut self, capset_index: u32) -> Result<RespCapsetInfo> {
+        self.require_virgl()?;
+        let rsp: RespCapsetInfo = self.request(CmdGetCapsetInfo {
+            header: CtrlHeader::with_type(Command::GET_CAPSET_INFO),
+            capset_index,
+            _padding: 0,
+        })?;
+        rsp.header.check_type(Command::OK_CAPSET_INFO)?;
+        Ok(rsp)
+    }
+
+    /// Retrieve capset data for a given capset ID and version.
+    ///
+    /// `size` must be the capset's `capset_max_size` as returned by
+    /// [`get_capset_info`](Self::get_capset_info), bounded by the receive buffer.
+    /// Returns `Err` rather than panicking if `size` exceeds the buffer.
+    pub fn get_capset(&mut self, capset_id: u32, version: u32, size: u32) -> Result<Vec<u8>> {
+        self.require_virgl()?;
+        if size as usize > self.queue_buf_recv.len() - size_of::<CtrlHeader>() {
+            return Err(Error::IoError);
+        }
+        let _: CtrlHeader = self.request(CmdGetCapset {
+            header: CtrlHeader::with_type(Command::GET_CAPSET),
+            capset_id,
+            capset_version: version,
+        })?;
+        // The response is a CtrlHeader (24 bytes) followed by `size` bytes of
+        // capset data, both placed back in queue_buf_recv.
+        let hdr = CtrlHeader::read_from_prefix(&self.queue_buf_recv)
+            .unwrap()
+            .0;
+        hdr.check_type(Command::OK_CAPSET)?;
+        let start = size_of::<CtrlHeader>();
+        let end = start + size as usize;
+        Ok(self.queue_buf_recv[start..end].to_vec())
+    }
+
+    /// Create a 3D rendering context.
+    ///
+    /// `ctx_id` is assigned by the upper layer. `name` is a debug label for the
+    /// host (truncated to 64 bytes).
+    ///
+    /// `context_init` carries the capset_id (e.g. 1 for VIRGL, 2 for VIRGL2).
+    /// Linux: `vfpriv->context_init` → `cmd_p->context_init` in the wire command.
+    pub fn ctx_create(&mut self, ctx_id: u32, name: &str, context_init: u32) -> Result {
+        self.require_virgl()?;
+        let mut debug_name = [0u8; 64];
+        let bytes = name.as_bytes();
+        let nlen = bytes.len().min(64);
+        debug_name[..nlen].copy_from_slice(&bytes[..nlen]);
+
+        let rsp: CtrlHeader = self.request(CmdCtxCreate {
+            header: CtrlHeader::with_type_and_ctx(Command::CTX_CREATE, ctx_id),
+            nlen: nlen as u32,
+            context_init,
+            debug_name,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Destroy a 3D rendering context.
+    pub fn ctx_destroy(&mut self, ctx_id: u32) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader =
+            self.request(CtrlHeader::with_type_and_ctx(Command::CTX_DESTROY, ctx_id))?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Attach a resource to a 3D context.
+    pub fn ctx_attach_resource(&mut self, ctx_id: u32, resource_id: u32) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader = self.request(CmdCtxResource {
+            header: CtrlHeader::with_type_and_ctx(Command::CTX_ATTACH_RESOURCE, ctx_id),
+            resource_id,
+            _padding: 0,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Detach a resource from a 3D context.
+    pub fn ctx_detach_resource(&mut self, ctx_id: u32, resource_id: u32) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader = self.request(CmdCtxResource {
+            header: CtrlHeader::with_type_and_ctx(Command::CTX_DETACH_RESOURCE, ctx_id),
+            resource_id,
+            _padding: 0,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Create a 3D resource (texture, render target, buffer, etc.).
+    ///
+    /// `target`, `format`, `bind`, `flags`, etc. are pipe-level constants
+    /// (e.g. PIPE_TEXTURE_2D, PIPE_FORMAT_B8G8R8A8_UNORM, PIPE_BIND_RENDER_TARGET).
+    /// The virtio-drivers layer does not define these — the caller passes raw
+    /// values from the Gallium/Mesa headers.
+    #[allow(clippy::too_many_arguments)]
+    pub fn resource_create_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        target: u32,
+        format: u32,
+        bind: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        array_size: u32,
+        last_level: u32,
+        nr_samples: u32,
+        flags: u32,
+    ) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader = self.request(CmdResourceCreate3D {
+            header: CtrlHeader::with_type_and_ctx(Command::RESOURCE_CREATE_3D, ctx_id),
+            resource_id,
+            target,
+            format,
+            bind,
+            width,
+            height,
+            depth,
+            array_size,
+            last_level,
+            nr_samples,
+            flags,
+            _padding: 0,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Transfer data from guest to host for a 3D resource.
+    #[allow(clippy::too_many_arguments)]
+    pub fn transfer_to_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: GpuBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader = self.request(CmdTransferHost3D {
+            header: CtrlHeader::with_type_and_ctx(Command::TRANSFER_TO_HOST_3D, ctx_id),
+            box_,
+            offset,
+            resource_id,
+            level,
+            stride,
+            layer_stride,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Transfer data from host to guest for a 3D resource.
+    #[allow(clippy::too_many_arguments)]
+    pub fn transfer_from_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: GpuBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result {
+        self.require_virgl()?;
+        let rsp: CtrlHeader = self.request(CmdTransferHost3D {
+            header: CtrlHeader::with_type_and_ctx(Command::TRANSFER_FROM_HOST_3D, ctx_id),
+            box_,
+            offset,
+            resource_id,
+            level,
+            stride,
+            layer_stride,
+        })?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Submit a virgl command stream to a 3D context.
+    ///
+    /// `cmds` is the encoded virgl command stream produced by the Mesa virgl
+    /// Gallium driver in userspace. It is sent as a separate scatter-gather
+    /// buffer alongside the SUBMIT_3D header.
+    ///
+    /// `fence_id` is assigned by the upper layer. The host signals the fence
+    /// once the command stream has been fully processed.
+    pub fn submit_3d(&mut self, ctx_id: u32, fence_id: u64, cmds: &[u8]) -> Result {
+        self.require_virgl()?;
+        // The virgl command stream is a sequence of 32-bit dwords; the host
+        // passes `size / 4` dwords to `virgl_renderer_submit_cmd`, so a length
+        // that is not a multiple of 4 would be silently truncated.
+        if cmds.len() % 4 != 0 {
+            return Err(Error::InvalidParam);
+        }
+        let size = u32::try_from(cmds.len()).map_err(|_| Error::IoError)?;
+        let rsp: CtrlHeader = self.request_with_data(
+            CmdSubmit3D {
+                header: CtrlHeader::with_fence(Command::SUBMIT_3D, ctx_id, fence_id),
+                size,
+                _padding: 0,
+            },
+            cmds,
+        )?;
+        rsp.check_type(Command::OK_NODATA)
+    }
+
+    /// Create a blob resource (host-visible memory / dma-buf sharing).
+    ///
+    /// Requires `VIRTIO_GPU_F_RESOURCE_BLOB` (see [`has_resource_blob`]).
+    ///
+    /// - `blob_mem`: `VIRTIO_GPU_BLOB_MEM_GUEST (0x1)`, `HOST3D (0x2)` or
+    ///   `HOST3D_GUEST (0x3)`.
+    /// - `blob_flags`: `VIRTIO_GPU_BLOB_FLAG_USE_MAPPABLE (0x1)` etc.
+    /// - `size`: resource size in bytes.
+    /// - `blob_id`: opaque host-side id (0 unless assigning one).
+    /// - `mem_entries`: guest backing `(addr, len)` pairs, only for GUEST /
+    ///   HOST3D_GUEST. **HOST3D must pass an empty slice** — QEMU ignores
+    ///   backing entries for HOST3D blobs, and virglrenderer rejects blobs
+    ///   with a nonzero `num_iovs`.
+    ///
+    /// Mirrors Linux `virtio_gpu_cmd_resource_create_blob` (`virtgpu_vq.c`).
+    /// Responds with OK_NODATA.
+    pub fn resource_create_blob(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        blob_mem: u32,
+        blob_flags: u32,
+        size: u64,
+        blob_id: u64,
+        mem_entries: &[(u64, u32)],
+    ) -> Result {
+        self.require_virgl()?;
+        if !self.has_resource_blob {
+            return Err(Error::Unsupported);
+        }
+        let nr_entries = u32::try_from(mem_entries.len()).map_err(|_| Error::IoError)?;
+        let mut data = Vec::with_capacity(mem_entries.len() * core::mem::size_of::<MemEntry>());
+        for (addr, len) in mem_entries {
+            data.extend_from_slice(
+                MemEntry {
+                    addr: *addr,
+                    length: *len,
+                    padding: 0,
+                }
+                .as_bytes(),
+            );
+        }
+        let rsp: CtrlHeader = self.request_with_data(
+            CmdResourceCreateBlob {
+                header: CtrlHeader::with_type_and_ctx(Command::RESOURCE_CREATE_BLOB, ctx_id),
+                resource_id,
+                blob_mem,
+                blob_flags,
+                nr_entries,
+                blob_id,
+                size,
+            },
+            &data,
+        )?;
+        rsp.check_type(Command::OK_NODATA)
+    }
 }
 
 impl<H: Hal, T: Transport> Drop for VirtIOGpu<H, T> {
@@ -403,6 +780,7 @@ impl<H: Hal, T: Transport> Drop for VirtIOGpu<H, T> {
 }
 
 #[repr(C)]
+#[derive(FromBytes, Immutable, IntoBytes)]
 struct Config {
     /// Signals pending events to the driver。
     events_read: ReadOnly<u32>,
@@ -414,6 +792,9 @@ struct Config {
     ///
     /// Minimum value is 1, maximum value is 16.
     num_scanouts: ReadOnly<u32>,
+
+    /// Specifies the number of capsets supported by the device.
+    num_capsets: ReadOnly<u32>,
 }
 
 /// Display configuration has changed.
@@ -426,6 +807,10 @@ bitflags! {
         const VIRGL                 = 1 << 0;
         /// EDID is supported.
         const EDID                  = 1 << 1;
+        /// Context init protocol (virgl2 capset, per-fd context). bit 4 per Linux UAPI!
+        const CONTEXT_INIT          = 1 << 4;
+        /// Blob resources (host-visible memory, dma-buf sharing) are supported.
+        const RESOURCE_BLOB         = 1 << 3;
 
         // device independent
         const NOTIFY_ON_EMPTY       = 1 << 24; // legacy
@@ -461,19 +846,36 @@ impl Command {
     const GET_CAPSET_INFO: Command = Command(0x108);
     const GET_CAPSET: Command = Command(0x109);
     const GET_EDID: Command = Command(0x10a);
+    const RESOURCE_CREATE_BLOB: Command = Command(0x10c);
 
+    // 3D commands (VirtIO-GPU spec Section 5.7.5, Table 5.7.5.2)
+    const CTX_CREATE: Command = Command(0x0200);
+    const CTX_DESTROY: Command = Command(0x0201);
+    const CTX_ATTACH_RESOURCE: Command = Command(0x0202);
+    const CTX_DETACH_RESOURCE: Command = Command(0x0203);
+    const RESOURCE_CREATE_3D: Command = Command(0x0204);
+    const TRANSFER_TO_HOST_3D: Command = Command(0x0205);
+    const TRANSFER_FROM_HOST_3D: Command = Command(0x0206);
+    const SUBMIT_3D: Command = Command(0x0207);
+
+    // Cursor commands
     const UPDATE_CURSOR: Command = Command(0x300);
     const MOVE_CURSOR: Command = Command(0x301);
 
+    // Success responses
     const OK_NODATA: Command = Command(0x1100);
     const OK_DISPLAY_INFO: Command = Command(0x1101);
     const OK_CAPSET_INFO: Command = Command(0x1102);
     const OK_CAPSET: Command = Command(0x1103);
     const OK_EDID: Command = Command(0x1104);
 
+    // Error responses
     const ERR_UNSPEC: Command = Command(0x1200);
     const ERR_OUT_OF_MEMORY: Command = Command(0x1201);
     const ERR_INVALID_SCANOUT_ID: Command = Command(0x1202);
+    const ERR_INVALID_RESOURCE_ID: Command = Command(0x1203);
+    const ERR_INVALID_CONTEXT_ID: Command = Command(0x1204);
+    const ERR_INVALID_PARAMETER: Command = Command(0x1205);
 }
 
 const GPU_FLAG_FENCE: u32 = 1 << 0;
@@ -485,7 +887,10 @@ struct CtrlHeader {
     flags: u32,
     fence_id: u64,
     ctx_id: u32,
-    _padding: u32,
+    /// Ring index for fence. Only used when VIRTIO_GPU_FLAG_INFO_RING_IDX is set
+    /// in `flags` (requires VIRTIO_GPU_F_CONTEXT_INIT, which is a virgl2 feature).
+    ring_idx: u8,
+    _padding: [u8; 3],
 }
 
 impl CtrlHeader {
@@ -495,7 +900,35 @@ impl CtrlHeader {
             flags: 0,
             fence_id: 0,
             ctx_id: 0,
-            _padding: 0,
+            ring_idx: 0,
+            _padding: [0; 3],
+        }
+    }
+
+    /// Create a CtrlHeader with the given command type and context ID.
+    /// Used for 3D commands that target a specific rendering context.
+    fn with_type_and_ctx(hdr_type: Command, ctx_id: u32) -> CtrlHeader {
+        CtrlHeader {
+            hdr_type,
+            flags: 0,
+            fence_id: 0,
+            ctx_id,
+            ring_idx: 0,
+            _padding: [0; 3],
+        }
+    }
+
+    /// Create a CtrlHeader with the given command type, context ID, and fence.
+    /// Used for SUBMIT_3D to signal fence completion after the command stream
+    /// has been processed.
+    fn with_fence(hdr_type: Command, ctx_id: u32, fence_id: u64) -> CtrlHeader {
+        CtrlHeader {
+            hdr_type,
+            flags: GPU_FLAG_FENCE,
+            fence_id,
+            ctx_id,
+            ring_idx: 0,
+            _padding: [0; 3],
         }
     }
 
@@ -509,13 +942,18 @@ impl CtrlHeader {
     }
 }
 
+/// Rectangle region used by 2D operations (scanout, flush, transfer).
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default, FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct Rect {
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
+pub struct Rect {
+    /// X offset.
+    pub x: u32,
+    /// Y offset.
+    pub y: u32,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
 }
 
 #[repr(C)]
@@ -614,6 +1052,167 @@ struct ResourceFlush {
     resource_id: u32,
     _padding: u32,
 }
+
+// -----------------------------------------------------------------------
+// 3D command/response structures (VirtIO-GPU spec §5.7.5, Table 5.7.5.2)
+// -----------------------------------------------------------------------
+
+/// 3D box used by TRANSFER_TO_HOST_3D and TRANSFER_FROM_HOST_3D.
+/// Describes a sub-rectangle within a 3D texture.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default, Immutable, IntoBytes, KnownLayout)]
+pub struct GpuBox {
+    /// X offset within the resource.
+    pub x: u32,
+    /// Y offset within the resource.
+    pub y: u32,
+    /// Z offset within the resource.
+    pub z: u32,
+    /// Width of the sub-region.
+    pub w: u32,
+    /// Height of the sub-region.
+    pub h: u32,
+    /// Depth of the sub-region.
+    pub d: u32,
+}
+
+/// VIRTIO_GPU_CMD_GET_CAPSET_INFO
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdGetCapsetInfo {
+    header: CtrlHeader,
+    capset_index: u32,
+    _padding: u32,
+}
+
+/// VIRTIO_GPU_RESP_OK_CAPSET_INFO
+#[repr(C)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
+pub struct RespCapsetInfo {
+    header: CtrlHeader,
+    /// Capset ID (1 = VIRGL, 2 = VIRGL2).
+    pub capset_id: u32,
+    /// Maximum version of this capset supported by the device.
+    pub capset_max_version: u32,
+    /// Maximum size in bytes of one capset data blob.
+    pub capset_max_size: u32,
+    _padding: u32,
+}
+
+/// VIRTIO_GPU_CMD_GET_CAPSET
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdGetCapset {
+    header: CtrlHeader,
+    capset_id: u32,
+    capset_version: u32,
+}
+
+/// VIRTIO_GPU_CMD_CTX_CREATE
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdCtxCreate {
+    header: CtrlHeader,
+    /// Length of the debug name (0..64).
+    nlen: u32,
+    /// Context init flags (used by virgl2 / VIRTIO_GPU_F_CONTEXT_INIT, 0 for virgl1).
+    context_init: u32,
+    /// Null-terminated debug name, 64 bytes.
+    debug_name: [u8; 64],
+}
+
+/// VIRTIO_GPU_CMD_CTX_ATTACH_RESOURCE, VIRTIO_GPU_CMD_CTX_DETACH_RESOURCE
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdCtxResource {
+    header: CtrlHeader,
+    resource_id: u32,
+    _padding: u32,
+}
+
+/// VIRTIO_GPU_CMD_RESOURCE_CREATE_3D
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdResourceCreate3D {
+    header: CtrlHeader,
+    resource_id: u32,
+    /// Pipe texture target (PIPE_TEXTURE_2D, PIPE_TEXTURE_3D, PIPE_BUFFER, …).
+    target: u32,
+    /// Pipe format (PIPE_FORMAT_*).
+    format: u32,
+    /// Pipe bind flags (PIPE_BIND_*).
+    bind: u32,
+    width: u32,
+    height: u32,
+    depth: u32,
+    array_size: u32,
+    /// Number of mipmap levels.
+    last_level: u32,
+    /// Number of MSAA samples.
+    nr_samples: u32,
+    /// Resource flags (VIRTIO_GPU_RESOURCE_FLAG_* from the Linux UAPI).
+    flags: u32,
+    _padding: u32,
+}
+
+/// VIRTIO_GPU_CMD_TRANSFER_TO_HOST_3D, VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdTransferHost3D {
+    header: CtrlHeader,
+    box_: GpuBox,
+    /// Byte offset within the resource.
+    offset: u64,
+    resource_id: u32,
+    /// Mipmap level.
+    level: u32,
+    /// Row stride in bytes.
+    stride: u32,
+    /// Layer stride in bytes (for array textures and 3D textures).
+    layer_stride: u32,
+}
+
+/// VIRTIO_GPU_CMD_SUBMIT_3D
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdSubmit3D {
+    header: CtrlHeader,
+    /// Size of the virgl command stream that follows in a separate buffer.
+    size: u32,
+    _padding: u32,
+}
+
+/// VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB
+///
+/// Field order matches `struct virtio_gpu_resource_create_blob` in the UAPI
+/// header exactly: `resource_id, blob_mem, blob_flags, nr_entries, blob_id, size`.
+/// `nr_entries > 0` mem entries follow as a separate buffer (see
+/// [`VirtIOGpu::resource_create_blob`]).
+#[repr(C)]
+#[derive(Debug, Immutable, IntoBytes, KnownLayout)]
+struct CmdResourceCreateBlob {
+    header: CtrlHeader,
+    resource_id: u32,
+    blob_mem: u32,
+    blob_flags: u32,
+    nr_entries: u32,
+    blob_id: u64,
+    size: u64,
+}
+
+/// One entry of a blob resource backing (guest memory for GUEST / HOST3D_GUEST).
+/// Matches `struct virtio_gpu_mem_entry { __le64 addr; __le32 length; __le32 padding; }`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Immutable, IntoBytes, KnownLayout)]
+struct MemEntry {
+    addr: u64,
+    length: u32,
+    padding: u32,
+}
+
+// -----------------------------------------------------------------------
+// End of 3D structures
+// -----------------------------------------------------------------------
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Immutable, IntoBytes, KnownLayout)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod transport;
 use device::socket::SocketError;
 use thiserror::Error;
 
-pub use self::hal::{BufferDirection, Dma, Hal, PhysAddr};
+pub use self::hal::{BufferDirection, Hal, PhysAddr};
 pub use safe_mmio::UniqueMmioPointer;
 
 /// The page size in bytes supported by the library (4 KiB).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod transport;
 use device::socket::SocketError;
 use thiserror::Error;
 
-pub use self::hal::{BufferDirection, Hal, PhysAddr};
+pub use self::hal::{BufferDirection, Dma, Hal, PhysAddr};
 pub use safe_mmio::UniqueMmioPointer;
 
 /// The page size in bytes supported by the library (4 KiB).


### PR DESCRIPTION
# virtio-gpu: add virgl 3D / blob support with a runtime-gated regression test

## Summary

This PR adds the low-level VirtIO-GPU command layer needed for 3D (virgl) operation to the existing 2D driver, then exercises the whole virgl path — feature negotiation, capset query, context lifecycle, 3D resource create/attach/detach, host transfers, fenced command submission and blob resources — through a new 15-step regression test in the x86_64 example.

The test is **runtime-gated** on the negotiated `VIRGL` feature, so plain 2D hosts and GL-capable hosts both "just work" with zero coupling between the Rust build and the QEMU device.

## Changes

### 1. Driver API — `src/device/gpu/mod.rs` (+645)

**2D protocol layer** (low-level commands the existing high-level helpers build on): `resource_create_2d`, `set_scanout`, `resource_flush`, `transfer_to_host_2d`, `resource_attach_backing`, `resource_detach_backing`, `resource_unref`.

**3D / virgl API** (new): `has_virgl`, `has_resource_blob`, `get_capset_info`, `get_capset`, `ctx_create` (3-arg, takes the capset id), `ctx_destroy`, `ctx_attach_resource`, `ctx_detach_resource`, `resource_create_3d`, `transfer_to_host_3d`, `transfer_from_host_3d`, `submit_3d`, `resource_create_blob`.

**Supporting types/constants**: `Rect`, `GpuBox`, `RespCapsetInfo`, command structs, `MemEntry`, feature bit constants (`VIRGL`/`EDID`/`CONTEXT_INIT`/`RESOURCE_BLOB`), protocol command/error constants (0x0200–0x0207, `RESOURCE_CREATE_BLOB` 0x10c, errors 0x1203–0x1205), and a `request_with_data` helper for multi-buffer requests.

**`QUEUE_SIZE` bumped 2 → 16**: `submit_3d` drives a 3-buffer command (header + virgl stream + response) that must fit the descriptor table even under indirect descriptors.

### 2. Example — `examples/x86_64`

- **`src/virgl.rs` (new, ~300 lines)**: the 15-step virgl regression test, each step failing loudly with a numbered `[VIRGL] n/15` message for exact fault location.
- **`src/main.rs`**: `mod virgl;` + runtime gate — runs the 3D tests only when `gpu.has_virgl()`.
- **`Makefile`**: new `gl ?= off` switch selects the QEMU GPU device — `virtio-gpu-gl-pci,blob=on -display egl-headless` vs plain `virtio-gpu-pci`. No cargo feature introduced.

### 3. `src/lib.rs`

Re-export `Dma` from the hal layer.

### 4. `README.md`

Document the `make qemu gl=on` invocation and its requirements.

## Design notes

- **Runtime gating, not a cargo feature** — device capability is a property of the running device, so the test self-gates on `has_virgl()`; the Makefile `gl` flag only picks the QEMU device. Non-GL hosts are completely unaffected (verified).
- **Blob test uses `BLOB_MEM_GUEST`** — a `BLOB_MEM_HOST3D` blob requires a preceding virgl `VIRGL_PIPE_RES_CREATE` submit to register the blob_id in the context (virglrenderer `vrend_get_blob_pipe`), which `resource_create_blob` alone cannot express. A GUEST blob works with just a DMA region.
- **CLEAR needs a bound surface** — a bare CLEAR on a context with no framebuffer fails with `GL_INVALID_FRAMEBUFFER_OPERATION` (masked to OK_NODATA by QEMU). Step 10 therefore submits `CREATE_OBJECT(surface) → SET_FRAMEBUFFER_STATE → CLEAR` as one fenced stream so the render actually executes.
- **Transfers require guest backing** — virglrenderer rejects transfer commands on resources with no backing (`check_transfer_iovec`), so the test attaches guest memory before the host transfers.

## Testing

| Invocation | virgl 3D | blob | 2D path | Host-side errors |
|---|---|---|---|---|
| `make run gl=on` (KVM, default) | 15/15 pass | OK | pass | none |
| `make run gl=on accel=off` (TCG) | 15/15 pass | OK | pass | none |
| `make run` (plain 2D device) | skipped by design | — | pass | none |

All three QEMU runs are clean — no virglrenderer `context error`, `failed to dispatch`, or `Illegal command buffer` lines. `[VIRGL] === ALL 15 STEPS PASSED ===` is reached on the GL paths.

### End-to-end validation in a real OS ([tgoskits](https://github.com/zyc107109102/tgoskits) / StarryOS)

The driver was additionally validated in the tgoskits workspace (an integrated Rust workspace for OS/virtualization development, combining ArceOS, StarryOS and Axvisor behind a unified `cargo xtask` entry) by running the `virgl-test` app in StarryOS under QEMU on x86_64:

```
cargo xtask starry app qemu -t virgl-test --arch x86_64
```

All tests passed.

To confirm real 3D rendering through the exposed virgl context, the GL benchmark [glmark2](https://github.com/glmark2/glmark2) was also run and completed successfully:

```
=======================================================
    glmark2 2023.01
=======================================================
    OpenGL Information
    GL_VENDOR:      Mesa
    GL_RENDERER:    virgl (AMD Radeon 780M Graphics (radeonsi, phoenix, ACO, DR...)
    GL_VERSION:     OpenGL ES 3.2 Mesa 25.2.7
    Surface Config: buf=32 r=8 g=8 b=8 a=8 depth=32 stencil=0 samples=0
    Surface Size:   800x600 windowed
=======================================================
```

`GL_RENDERER: virgl` shows the app rendered through the virtual GPU onto the host's real GPU (AMD Radeon 780M / radeonsi) — i.e. actual 3D content was produced end-to-end. This is the pixel-level rendering proof that the example test (no readback API) cannot provide.

---

# 中文版

# virtio-gpu:添加 virgl 3D / blob 支持与运行时门控回归测试

## 概述

本 PR 为现有 2D 驱动补上 3D(virgl)所需的 VirtIO-GPU 协议命令层,并在 x86_64 example 中加入一套 15 步回归测试,覆盖 virgl 完整路径:feature 协商、capset 查询、context 生命周期、3D 资源创建/绑定/解绑、host 传输、fenced 命令提交与 blob 资源。

测试按协商到的 `VIRGL` feature **运行时自门控**——纯 2D host 与 GL host 都能直接运行,Rust 编译与 QEMU 设备选择零耦合。

## 改动

### 1. 驱动 API — `src/device/gpu/mod.rs`(+645)

**2D 协议层**(现有高层 API 依赖的低层命令):`resource_create_2d`、`set_scanout`、`resource_flush`、`transfer_to_host_2d`、`resource_attach_backing`、`resource_detach_backing`、`resource_unref`。

**3D / virgl API**(新增):`has_virgl`、`has_resource_blob`、`get_capset_info`、`get_capset`、`ctx_create`(三参,带 capset id)、`ctx_destroy`、`ctx_attach_resource`、`ctx_detach_resource`、`resource_create_3d`、`transfer_to_host_3d`、`transfer_from_host_3d`、`submit_3d`、`resource_create_blob`。

**配套类型/常量**:`Rect`、`GpuBox`、`RespCapsetInfo`、各命令结构体、`MemEntry`、feature 位常量(`VIRGL`/`EDID`/`CONTEXT_INIT`/`RESOURCE_BLOB`)、协议命令/错误常量(0x0200–0x0207、`RESOURCE_CREATE_BLOB` 0x10c、错误 0x1203–0x1205),以及多缓冲请求助手 `request_with_data`。

**`QUEUE_SIZE` 由 2 提升到 16**:`submit_3d` 需要驱动三缓冲命令(header + virgl 命令流 + 响应),即使开启间接描述符也必须容纳进描述符表。

### 2. x86_64 example

- **`src/virgl.rs`(新增,约 300 行)**:15 步 virgl 回归测试,每一步失败都会以编号 `[VIRGL] n/15` 信息精确定位故障点。
- **`src/main.rs`**:`mod virgl;` + 运行时门控——仅当 `gpu.has_virgl()` 为真时运行 3D 测试。
- **`Makefile`**:新增 `gl ?= off` 开关,切换 QEMU GPU 设备——`virtio-gpu-gl-pci,blob=on -display egl-headless` 与普通 `virtio-gpu-pci`。不引入任何 cargo feature。

### 3. `src/lib.rs`

从 hal 层再导出 `Dma`。

### 4. `README.md`

补充 `make qemu gl=on` 的用法与前提说明。

## 关键设计

- **运行时门控而非 cargo feature**——设备能力属于运行期属性,故测试用 `has_virgl()` 自门控;`gl` 开关只管 QEMU 设备选择。非 GL host 完全不受影响(已验证)。
- **blob 测试使用 `BLOB_MEM_GUEST`**——`BLOB_MEM_HOST3D` blob 需要先用 virgl 命令 `VIRGL_PIPE_RES_CREATE` 在 context 中注册 blob_id(见 virglrenderer `vrend_get_blob_pipe`),单靠 `resource_create_blob` 表达不了这个前置条件;GUEST blob 只需一段 DMA 内存即可。
- **CLEAR 必须绑定 surface**——裸 CLEAR 在未绑定 framebuffer 时触发 `GL_INVALID_FRAMEBUFFER_OPERATION`(QEMU 会吞掉该错误)。第 10 步因此一次性提交 `CREATE_OBJECT(surface) → SET_FRAMEBUFFER_STATE → CLEAR`,fence 之后渲染真正生效。
- **传输必须带 guest backing**——virglrenderer 会拒绝没有 backing 的资源上的传输命令(`check_transfer_iovec`),故测试在 host 传输前先 `resource_attach_backing`。

## 验证

| 调用方式 | virgl 3D | blob | 2D 路径 | host 侧错误 |
|---|---|---|---|---|
| `make run gl=on`(KVM,默认) | 15/15 通过 | 通过 | 通过 | 无 |
| `make run gl=on accel=off`(TCG) | 15/15 通过 | 通过 | 通过 | 无 |
| `make run`(普通 2D 设备) | 按设计跳过 | — | 通过 | 无 |

三种 QEMU 运行日志全部干净——无任何 virglrenderer context error / dispatch 失败 / 非法命令缓冲;GL 路径均到达 `[VIRGL] === ALL 15 STEPS PASSED ===`。

### 真实 OS 端到端验证([tgoskits](https://github.com/zyc107109102/tgoskits) / StarryOS)

另外在 tgoskits 工作区(集成了 ArceOS、StarryOS、Axvisor 的操作系统/虚拟化 Rust 工作区,统一 `cargo xtask` 入口)做了端到端验证:在 StarryOS 中通过 QEMU 在 x86_64 上运行 `virgl-test` 应用:

```
cargo xtask starry app qemu -t virgl-test --arch x86_64
```

全部通过。

同时运行了 GL 基准测试 [glmark2](https://github.com/glmark2/glmark2),确认通过驱动暴露的 virgl 上下文真实完成 3D 渲染:

```
=======================================================
    glmark2 2023.01
=======================================================
    OpenGL Information
    GL_VENDOR:      Mesa
    GL_RENDERER:    virgl (AMD Radeon 780M Graphics (radeonsi, phoenix, ACO, DR...)
    GL_VERSION:     OpenGL ES 3.2 Mesa 25.2.7
    Surface Config: buf=32 r=8 g=8 b=8 a=8 depth=32 stencil=0 samples=0
    Surface Size:   800x600 windowed
=======================================================
```

`GL_RENDERER: virgl` 表明应用经由虚拟 GPU 在主机真实 GPU(AMD Radeon 780M / radeonsi)上渲染,即端到端产出了真实 3D 内容——这正是 example 测试因无像素回读 API 而无法提供的像素级渲染证明。
<img width="640" height="360" alt="截图 2026-08-09 03-43-01" src="https://github.com/user-attachments/assets/85712dd1-14cc-4e77-9836-2e746f3a9463" />
